### PR TITLE
Replace uses of klogr for a passed through logr interface

### DIFF
--- a/adopt/adopt.go
+++ b/adopt/adopt.go
@@ -28,12 +28,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 
 	"github.com/authzed/controller-idioms/handler"
 	"github.com/authzed/controller-idioms/queue"
 	"github.com/authzed/controller-idioms/typed"
 	"github.com/authzed/controller-idioms/typedctx"
+	"github.com/go-logr/logr"
 )
 
 // TODO: a variant where there can only be one owner (label only, fail if labelled for someone else)
@@ -147,7 +147,7 @@ type AdoptionHandler[K Object, A Adoptable[A]] struct {
 }
 
 func (s *AdoptionHandler[K, A]) Handle(ctx context.Context) {
-	logger := klog.FromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	adoptee := s.AdopteeCtx.MustValue(ctx)
 	owner := s.OwnerCtx.MustValue(ctx)
 

--- a/bootstrap/resource.go
+++ b/bootstrap/resource.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,7 +28,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,7 +41,7 @@ type KubeResourceObject interface {
 // ResourceFromFile creates a KubeResourceObject with the given config file
 func ResourceFromFile[O KubeResourceObject](ctx context.Context, fieldManager string, gvr schema.GroupVersionResource, dclient dynamic.Interface, configPath string, lastHash uint64) (uint64, error) {
 	if len(configPath) <= 0 {
-		klog.V(4).Info("bootstrap file path not specified")
+		logr.FromContextOrDiscard(ctx).V(4).Info("bootstrap file path not specified")
 		return 0, nil
 	}
 
@@ -50,7 +50,7 @@ func ResourceFromFile[O KubeResourceObject](ctx context.Context, fieldManager st
 		utilruntime.HandleError(f.Close())
 	}()
 	if errors.Is(err, os.ErrNotExist) {
-		klog.V(4).Info("no bootstrap file present, skipping bootstrapping")
+		logr.FromContextOrDiscard(ctx).V(4).Info("no bootstrap file present, skipping bootstrapping")
 		return 0, nil
 	}
 	if err != nil {

--- a/bootstrap/resource_test.go
+++ b/bootstrap/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,10 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/klog/v2/klogr"
 )
 
 func ExampleResourceFromFile() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(logr.NewContext(context.Background(), klogr.New()))
 	defer cancel()
 
 	secretGVR := corev1.SchemeGroupVersion.WithResource("secrets")

--- a/fileinformer/file_informer.go
+++ b/fileinformer/file_informer.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 )
 
 // FileGroupVersion is a sythetic GroupVersion that the informers use.
@@ -26,6 +26,7 @@ var FileGroupVersion = schema.GroupVersion{
 // Factory implements dynamicinformer.DynamicSharedInformerFactory, but for
 // starting and managing FileInformers.
 type Factory struct {
+	log logr.Logger
 	sync.Mutex
 	informers map[schema.GroupVersionResource]informers.GenericInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -36,8 +37,9 @@ type Factory struct {
 var _ dynamicinformer.DynamicSharedInformerFactory = &Factory{}
 
 // NewFileInformerFactory creates a new Factory.
-func NewFileInformerFactory() (*Factory, error) {
+func NewFileInformerFactory(log logr.Logger) (*Factory, error) {
 	return &Factory{
+		log:              log,
 		informers:        make(map[schema.GroupVersionResource]informers.GenericInformer),
 		startedInformers: make(map[schema.GroupVersionResource]bool),
 	}, nil
@@ -71,7 +73,7 @@ func (f *Factory) ForResource(gvr schema.GroupVersionResource) informers.Generic
 	if err != nil {
 		panic(err)
 	}
-	informer, err = NewFileInformer(watcher, gvr)
+	informer, err = NewFileInformer(f.log, watcher, gvr)
 	if err != nil {
 		panic(err)
 	}
@@ -104,6 +106,7 @@ func (f *Factory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersi
 
 // FileInformer is an informer that watches files instead of the kube api.
 type FileInformer struct {
+	log      logr.Logger
 	fileName string
 	watcher  *fsnotify.Watcher
 	informer cache.SharedIndexInformer
@@ -112,11 +115,12 @@ type FileInformer struct {
 var _ informers.GenericInformer = &FileInformer{}
 
 // NewFileInformer returns a new FileInformer.
-func NewFileInformer(watcher *fsnotify.Watcher, gvr schema.GroupVersionResource) (*FileInformer, error) {
+func NewFileInformer(log logr.Logger, watcher *fsnotify.Watcher, gvr schema.GroupVersionResource) (*FileInformer, error) {
 	return &FileInformer{
+		log:      log,
 		fileName: gvr.Resource,
 		watcher:  watcher,
-		informer: NewFileSharedIndexInformer(gvr.Resource, watcher, 1*time.Minute),
+		informer: NewFileSharedIndexInformer(log, gvr.Resource, watcher, 1*time.Minute),
 	}, nil
 }
 
@@ -130,6 +134,7 @@ func (f *FileInformer) Lister() cache.GenericLister {
 }
 
 type FileSharedIndexInformer struct {
+	log logr.Logger
 	sync.Once
 	sync.RWMutex
 	defaultEventHandlerResyncPeriod time.Duration
@@ -144,8 +149,9 @@ var _ cache.SharedIndexInformer = &FileSharedIndexInformer{}
 
 // NewFileSharedIndexInformer creates a new informer watching the file
 // Note that currently all event handlers share the default resync period.
-func NewFileSharedIndexInformer(fileName string, watcher *fsnotify.Watcher, defaultEventHandlerResyncPeriod time.Duration) *FileSharedIndexInformer {
+func NewFileSharedIndexInformer(log logr.Logger, fileName string, watcher *fsnotify.Watcher, defaultEventHandlerResyncPeriod time.Duration) *FileSharedIndexInformer {
 	return &FileSharedIndexInformer{
+		log:                             log.WithValues("file", fileName),
 		fileName:                        fileName,
 		watcher:                         watcher,
 		handlers:                        []cache.ResourceEventHandler{},
@@ -187,7 +193,7 @@ func (f *FileSharedIndexInformer) Run(stopCh <-chan struct{}) {
 		utilruntime.HandleError(f.watcher.Add(fileName))
 		f.started = true
 		f.Unlock()
-		klog.V(4).Infof("started watching %q", fileName)
+		f.log.V(4).Info("started watching")
 
 		if len(fileName) == 0 {
 			return
@@ -210,13 +216,13 @@ func (f *FileSharedIndexInformer) Run(stopCh <-chan struct{}) {
 				defer f.Unlock()
 				utilruntime.HandleError(f.watcher.Remove(fileName))
 				utilruntime.HandleError(f.watcher.Close())
-				klog.V(4).Infof("stopped watching %q", fileName)
+				f.log.V(4).Info("stopped watching")
 			}()
 			ctx, cancel := context.WithTimeout(context.Background(), f.defaultEventHandlerResyncPeriod)
 			for {
 				select {
 				case <-ctx.Done():
-					klog.V(4).Infof("resyncing file %s after %s", fileName, f.defaultEventHandlerResyncPeriod.String())
+					f.log.V(4).Info("resyncing file after %s", f.defaultEventHandlerResyncPeriod.String())
 					f.RLock()
 					for _, h := range f.handlers {
 						h.OnUpdate(fileName, fileName)
@@ -229,11 +235,11 @@ func (f *FileSharedIndexInformer) Run(stopCh <-chan struct{}) {
 						cancel()
 						return
 					}
-					klog.V(8).Infof("filewatcher got event %s for %q", event.String(), event.Name)
+					f.log.V(8).Info("filewatcher got event %s for %q", event.String(), event.Name)
 					if event.Name != fileName {
 						continue
 					}
-					klog.V(4).Infof("filewatcher got event %s for %q", event.String(), event.Name)
+					f.log.V(4).Info("filewatcher got event %s for %q", event.String(), event.Name)
 					if event.Op&fsnotify.Write == fsnotify.Write ||
 						event.Op&fsnotify.Create == fsnotify.Create {
 						f.RLock()

--- a/fileinformer/file_informer.go
+++ b/fileinformer/file_informer.go
@@ -222,7 +222,7 @@ func (f *FileSharedIndexInformer) Run(stopCh <-chan struct{}) {
 			for {
 				select {
 				case <-ctx.Done():
-					f.log.V(4).Info("resyncing file after %s", f.defaultEventHandlerResyncPeriod.String())
+					f.log.V(4).Info("resyncing file", "after", f.defaultEventHandlerResyncPeriod.String())
 					f.RLock()
 					for _, h := range f.handlers {
 						h.OnUpdate(fileName, fileName)
@@ -235,11 +235,11 @@ func (f *FileSharedIndexInformer) Run(stopCh <-chan struct{}) {
 						cancel()
 						return
 					}
-					f.log.V(8).Info("filewatcher got event %s for %q", event.String(), event.Name)
+					f.log.V(8).Info("filewatcher got event", "event", event.String(), "event_name", event.Name)
 					if event.Name != fileName {
 						continue
 					}
-					f.log.V(4).Info("filewatcher got event %s for %q", event.String(), event.Name)
+					f.log.V(4).Info("filewatcher got event", "event", event.String(), "event_name", event.Name)
 					if event.Op&fsnotify.Write == fsnotify.Write ||
 						event.Op&fsnotify.Create == fsnotify.Create {
 						f.RLock()

--- a/fileinformer/file_informer_test.go
+++ b/fileinformer/file_informer_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/klogr"
 )
 
 func TestFileInformer(t *testing.T) {
-	informerFactory, err := NewFileInformerFactory()
+	informerFactory, err := NewFileInformerFactory(klogr.New())
 	require.NoError(t, err)
 
 	file, err := os.CreateTemp("", "watched-file")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.5.4
+	github.com/go-logr/logr v1.2.3
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
 	github.com/prometheus/client_golang v1.13.0
 	github.com/stretchr/testify v1.8.0
@@ -35,7 +36,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect

--- a/manager/controller_test.go
+++ b/manager/controller_test.go
@@ -12,6 +12,7 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlmanageropts "k8s.io/controller-manager/options"
+	"k8s.io/klog/v2/klogr"
 
 	"github.com/authzed/controller-idioms/cachekeys"
 	"github.com/authzed/controller-idioms/queue"
@@ -31,7 +32,7 @@ func ExampleNewOwnedResourceController() {
 
 	// the controller processes objects on the queue, but doesn't set up any
 	// informers by default.
-	controller := NewOwnedResourceController("my-controller", gvr, CtxQueue, registry, broadcaster, func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) {
+	controller := NewOwnedResourceController(klogr.New(), "my-controller", gvr, CtxQueue, registry, broadcaster, func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) {
 		// process object
 	})
 
@@ -53,7 +54,7 @@ func TestControllerQueueDone(t *testing.T) {
 	broadcaster := record.NewBroadcaster()
 	eventSink := &typedcorev1.EventSinkImpl{Interface: fake.NewSimpleClientset().CoreV1().Events("")}
 
-	controller := NewOwnedResourceController("my-controller", gvr, CtxQueue, registry, broadcaster, func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) {
+	controller := NewOwnedResourceController(klogr.New(), "my-controller", gvr, CtxQueue, registry, broadcaster, func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) {
 	})
 
 	mgr := NewManager(ctrlmanageropts.RecommendedDebuggingOptions().DebuggingConfiguration, ":", broadcaster, eventSink)

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -5,9 +5,8 @@ import (
 	"encoding/base64"
 	"math/rand"
 
-	"k8s.io/klog/v2"
-
 	"github.com/authzed/controller-idioms/handler"
+	"github.com/go-logr/logr"
 )
 
 // NewSyncID returns a random string of length `size` that can be added to log
@@ -21,17 +20,17 @@ func NewSyncID(size uint8) string {
 }
 
 // NewHandlerLoggingMiddleware creates a new HandlerLoggingMiddleware for a
-// particular klog log level.
+// particular logr log level.
 func NewHandlerLoggingMiddleware(level int) Middleware {
 	return MakeMiddleware(HandlerLoggingMiddleware(level))
 }
 
-// HandlerLoggingMiddleware logs on entry to a handler. It uses the klog logger
+// HandlerLoggingMiddleware logs on entry to a handler. It uses the logr logger
 // found in the context.
 func HandlerLoggingMiddleware(level int) HandlerMiddleware {
 	return func(in handler.Handler) handler.Handler {
 		return handler.NewHandlerFromFunc(func(ctx context.Context) {
-			logger := klog.FromContext(ctx)
+			logger := logr.FromContextOrDiscard(ctx)
 			logger = logger.WithValues("handler", in.ID())
 			logger.V(level).Info("entering handler")
 			in.Handle(ctx)

--- a/queue/controls.go
+++ b/queue/controls.go
@@ -20,9 +20,8 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	"github.com/authzed/controller-idioms/typedctx"
+	"github.com/go-logr/logr"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -50,12 +49,12 @@ func (h OperationsContext) Requeue(ctx context.Context) {
 }
 
 func (h OperationsContext) RequeueErr(ctx context.Context, err error) {
-	klog.FromContext(ctx).V(4).WithCallDepth(3).Error(err, "requeueing after error")
+	logr.FromContextOrDiscard(ctx).V(4).WithCallDepth(3).Error(err, "requeueing after error")
 	h.MustValue(ctx).RequeueErr(err)
 }
 
 func (h OperationsContext) RequeueAPIErr(ctx context.Context, err error) {
-	klog.FromContext(ctx).V(4).WithCallDepth(3).Error(err, "requeueing after api error")
+	logr.FromContextOrDiscard(ctx).V(4).WithCallDepth(3).Error(err, "requeueing after api error")
 	h.MustValue(ctx).RequeueAPIErr(err)
 }
 

--- a/static/controller.go
+++ b/static/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/authzed/controller-idioms/bootstrap"
 	"github.com/authzed/controller-idioms/fileinformer"
 	"github.com/authzed/controller-idioms/manager"
+	"github.com/go-logr/logr"
 )
 
 type Controller[K bootstrap.KubeResourceObject] struct {
@@ -29,8 +30,8 @@ type Controller[K bootstrap.KubeResourceObject] struct {
 	lastStaticHash atomic.Uint64
 }
 
-func NewStaticController[K bootstrap.KubeResourceObject](name string, path string, gvr schema.GroupVersionResource, client dynamic.Interface) (*Controller[K], error) {
-	fileInformerFactory, err := fileinformer.NewFileInformerFactory()
+func NewStaticController[K bootstrap.KubeResourceObject](log logr.Logger, name string, path string, gvr schema.GroupVersionResource, client dynamic.Interface) (*Controller[K], error) {
+	fileInformerFactory, err := fileinformer.NewFileInformerFactory(log)
 	if err != nil {
 		return nil, err
 	}

--- a/static/controller_test.go
+++ b/static/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/klog/v2/klogr"
 )
 
 func ExampleController() {
@@ -29,7 +30,7 @@ func ExampleController() {
 
 	// start a static controller to create the object from the file
 	// the example is a secret, but it could be any built-in or CRD-defined type
-	controller, _ := NewStaticController[*corev1.Secret]("static-secret", "./example.yaml", secretGVR, client)
+	controller, _ := NewStaticController[*corev1.Secret](klogr.New(), "static-secret", "./example.yaml", secretGVR, client)
 	go controller.Start(ctx, 1)
 
 	for {


### PR DESCRIPTION
It is important to me as a library consumer that:

1. I am able to define the logger used in the library (though that is typically always klogr for me), and
2. Able to give unified context in my project's logging.

[logr](https://github.com/go-logr/logr) is a go logger interface which aims to unify logging implementations in a sane way.

This PR replaces all instances of `klog.Info...` with a passed through `logr.Logger` equivalent.

Sometimes we fetch the logger from context, sometimes passed through when instantiating a new struct. Hopefully either choice makes sense for the case.

There aren't any opinionated uses of `WithName` in this PR, which might be considered implementing.

---

This is a breaking change, though I don't know if that matters since this project is pre v1.