### PR TITLE
queue.Operations: add context cancelation and record error

### DIFF
--- a/component/ensure_component_test.go
+++ b/component/ensure_component_test.go
@@ -144,7 +144,7 @@ func TestEnsureServiceHandler(t *testing.T) {
 						}),
 					hash.NewObjectHash(), hashKey),
 				ctxOwner,
-				queueOps.Key,
+				queueOps,
 				func(ctx context.Context, apply *applycorev1.ServiceApplyConfiguration) (*corev1.Service, error) {
 					applyCalled = true
 					return nil, nil

--- a/manager/controller.go
+++ b/manager/controller.go
@@ -32,10 +32,11 @@ import (
 	"k8s.io/controller-manager/controller"
 	controllerhealthz "k8s.io/controller-manager/pkg/healthz"
 
+	"github.com/go-logr/logr"
+
 	"github.com/authzed/controller-idioms/cachekeys"
 	"github.com/authzed/controller-idioms/queue"
 	"github.com/authzed/controller-idioms/typed"
-	"github.com/go-logr/logr"
 )
 
 // SyncFunc is a function called when an event needs processing
@@ -162,7 +163,7 @@ func (c *OwnedResourceController) processNext(ctx context.Context) bool {
 		c.Queue.AddAfter(key, after)
 	}
 
-	ctx = c.OperationsContext.WithValue(ctx, queue.NewOperations(done, requeue))
+	ctx = c.OperationsContext.WithValue(ctx, queue.NewOperations(done, requeue, cancel))
 
 	c.sync(ctx, *gvr, namespace, name)
 	done()

--- a/queue/controls_test.go
+++ b/queue/controls_test.go
@@ -25,7 +25,7 @@ func ExampleNewOperations() {
 		queue.Done(key)
 	}, func(duration time.Duration) {
 		queue.AddAfter(key, duration)
-	})
+	}, cancel)
 
 	// typically called from a handler
 	handler.NewHandlerFromFunc(func(ctx context.Context) {
@@ -57,7 +57,7 @@ func ExampleNewQueueOperationsCtx() {
 		queue.Done(key)
 	}, func(duration time.Duration) {
 		queue.AddAfter(key, duration)
-	}))
+	}, cancel))
 
 	// queue controls are passed via context
 	handler.NewHandlerFromFunc(func(ctx context.Context) {

--- a/queue/fake/zz_generated.go
+++ b/queue/fake/zz_generated.go
@@ -13,6 +13,16 @@ type FakeInterface struct {
 	doneMutex       sync.RWMutex
 	doneArgsForCall []struct {
 	}
+	ErrorStub        func() error
+	errorMutex       sync.RWMutex
+	errorArgsForCall []struct {
+	}
+	errorReturns struct {
+		result1 error
+	}
+	errorReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RequeueStub        func()
 	requeueMutex       sync.RWMutex
 	requeueArgsForCall []struct {
@@ -58,6 +68,59 @@ func (fake *FakeInterface) DoneCalls(stub func()) {
 	fake.doneMutex.Lock()
 	defer fake.doneMutex.Unlock()
 	fake.DoneStub = stub
+}
+
+func (fake *FakeInterface) Error() error {
+	fake.errorMutex.Lock()
+	ret, specificReturn := fake.errorReturnsOnCall[len(fake.errorArgsForCall)]
+	fake.errorArgsForCall = append(fake.errorArgsForCall, struct {
+	}{})
+	stub := fake.ErrorStub
+	fakeReturns := fake.errorReturns
+	fake.recordInvocation("Error", []interface{}{})
+	fake.errorMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeInterface) ErrorCallCount() int {
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
+	return len(fake.errorArgsForCall)
+}
+
+func (fake *FakeInterface) ErrorCalls(stub func() error) {
+	fake.errorMutex.Lock()
+	defer fake.errorMutex.Unlock()
+	fake.ErrorStub = stub
+}
+
+func (fake *FakeInterface) ErrorReturns(result1 error) {
+	fake.errorMutex.Lock()
+	defer fake.errorMutex.Unlock()
+	fake.ErrorStub = nil
+	fake.errorReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeInterface) ErrorReturnsOnCall(i int, result1 error) {
+	fake.errorMutex.Lock()
+	defer fake.errorMutex.Unlock()
+	fake.ErrorStub = nil
+	if fake.errorReturnsOnCall == nil {
+		fake.errorReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.errorReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeInterface) Requeue() {
@@ -185,6 +248,8 @@ func (fake *FakeInterface) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.doneMutex.RLock()
 	defer fake.doneMutex.RUnlock()
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
 	fake.requeueMutex.RLock()
 	defer fake.requeueMutex.RUnlock()
 	fake.requeueAPIErrMutex.RLock()


### PR DESCRIPTION
This addresses an important case where a (preexisting) handler is wrapped in another handler

Canceling the context when a queue operation is performed signals to wrappers that the handler chain should stop (and also protects against accidental further processing, i.e. with a kube client)

Recording the error on the operations context (which is similar to context.Context) gives the caller a chance to do something with the error before returning.

Example:
```go
var Queue = queue.NewQueueOperationsCtx()

func (s *Wrapper) Handle(ctx context.Context) {
	otherHandler.Handle(ctx)
        if errors.Is(ctx.Err(), context.Canceled) {
            if err := Queue.Error(ctx); err != nil {
                logger.V(2).Error(, "error calling underlying handler")
            }
            return
        }
	s.next.Handle(ctx)
}
```