### PR TITLE
Add non-panicing versions of ListerFor, IndexerFor 

### DIFF
--- a/adopt/adopt.go
+++ b/adopt/adopt.go
@@ -86,11 +86,11 @@ const Owned = "owned"
 
 var (
 	// AlwaysExistsFunc is an ExistsFunc that always returns nil
-	AlwaysExistsFunc ExistsFunc = func(ctx context.Context, nn types.NamespacedName) error {
+	AlwaysExistsFunc ExistsFunc = func(_ context.Context, _ types.NamespacedName) error {
 		return nil
 	}
 	// NoopObjectMissingFunc is an ObjectMissing func that does nothing
-	NoopObjectMissingFunc = func(ctx context.Context, err error) {}
+	NoopObjectMissingFunc = func(_ context.Context, _ error) {}
 )
 
 // AdoptionHandler implements handler.Handler to "adopt" an existing resource

--- a/adopt/adopt_test.go
+++ b/adopt/adopt_test.go
@@ -46,7 +46,7 @@ func TestSecretAdopterHandler(t *testing.T) {
 		err    error
 	}
 
-	secretNotFound := func(name string) error {
+	secretNotFound := func(_ string) error {
 		return apierrors.NewNotFound(
 			corev1.SchemeGroupVersion.WithResource("secrets").GroupResource(),
 			"test")

--- a/adopt/adopt_test.go
+++ b/adopt/adopt_test.go
@@ -324,21 +324,21 @@ func TestSecretAdopterHandler(t *testing.T) {
 			applyCallIndex := 0
 			s := NewSecretAdoptionHandler(
 				recorder,
-				func(ctx context.Context) (*corev1.Secret, error) {
+				func(_ context.Context) (*corev1.Secret, error) {
 					return tt.secretInCache, tt.cacheErr
 				},
-				func(ctx context.Context, err error) {
+				func(_ context.Context, err error) {
 					require.Equal(t, tt.expectObjectMissingErr, err)
 				},
 				typed.NewIndexer[*corev1.Secret](indexer),
-				func(ctx context.Context, secret *applycorev1.SecretApplyConfiguration, opts metav1.ApplyOptions) (result *corev1.Secret, err error) {
+				func(_ context.Context, secret *applycorev1.SecretApplyConfiguration, _ metav1.ApplyOptions) (result *corev1.Secret, err error) {
 					defer func() { applyCallIndex++ }()
 					call := tt.applyCalls[applyCallIndex]
 					call.called = true
 					require.Equal(t, call.input, secret, "error on call %d", applyCallIndex)
 					return call.result, call.err
 				},
-				func(ctx context.Context, nn types.NamespacedName) error {
+				func(_ context.Context, _ types.NamespacedName) error {
 					return tt.secretExistsErr
 				},
 				handler.NewHandlerFromFunc(func(ctx context.Context) {

--- a/bootstrap/crds.go
+++ b/bootstrap/crds.go
@@ -117,7 +117,7 @@ func waitForDiscovery(ctx context.Context, config *rest.Config, crds []*apiexten
 		return err
 	}
 
-	return wait.PollUntilContextTimeout(ctx, crdInstallPollInterval, maxCRDInstallTime, true, func(ctx context.Context) (done bool, err error) {
+	return wait.PollUntilContextTimeout(ctx, crdInstallPollInterval, maxCRDInstallTime, true, func(_ context.Context) (done bool, err error) {
 		_, serverGVRs, err := discoveryClient.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil

--- a/component/ensure_component_test.go
+++ b/component/ensure_component_test.go
@@ -137,7 +137,7 @@ func TestEnsureServiceHandler(t *testing.T) {
 					NewIndexedComponent(
 						indexer,
 						ownerIndex,
-						func(ctx context.Context) labels.Selector {
+						func(_ context.Context) labels.Selector {
 							return labels.SelectorFromSet(map[string]string{
 								"example.com/component": "the-main-service-component",
 							})
@@ -145,15 +145,15 @@ func TestEnsureServiceHandler(t *testing.T) {
 					hash.NewObjectHash(), hashKey),
 				ctxOwner,
 				queueOps,
-				func(ctx context.Context, apply *applycorev1.ServiceApplyConfiguration) (*corev1.Service, error) {
+				func(_ context.Context, _ *applycorev1.ServiceApplyConfiguration) (*corev1.Service, error) {
 					applyCalled = true
 					return nil, nil
 				},
-				func(ctx context.Context, nn types.NamespacedName) error {
+				func(_ context.Context, _ types.NamespacedName) error {
 					deleteCalled = true
 					return nil
 				},
-				func(ctx context.Context) *applycorev1.ServiceApplyConfiguration {
+				func(_ context.Context) *applycorev1.ServiceApplyConfiguration {
 					return applycorev1.Service("test", "test").
 						WithLabels(map[string]string{
 							"example.com/component": "the-main-service-component",

--- a/component/ensure_component_test.go
+++ b/component/ensure_component_test.go
@@ -122,7 +122,7 @@ func TestEnsureServiceHandler(t *testing.T) {
 			client := clientfake.NewSimpleDynamicClient(scheme, tt.existingServices...)
 			informerFactory := dynamicinformer.NewDynamicSharedInformerFactory(client, 0)
 			require.NoError(t, informerFactory.ForResource(serviceGVR).Informer().AddIndexers(map[string]cache.IndexFunc{
-				ownerIndex: func(obj interface{}) ([]string, error) {
+				ownerIndex: func(_ interface{}) ([]string, error) {
 					return []string{types.NamespacedName{Namespace: "test", Name: "owner"}.String()}, nil
 				},
 			}))

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -127,7 +127,7 @@ func (f Builder) Handler(id Key) Handler {
 }
 
 // NoopHandler is a handler that does nothing
-var NoopHandler = NewHandler(ContextHandlerFunc(func(ctx context.Context) {}), NextKey)
+var NoopHandler = NewHandler(ContextHandlerFunc(func(_ context.Context) {}), NextKey)
 
 // Key is used to identify a given Handler in a set of Handlers
 type Key string

--- a/manager/controller_test.go
+++ b/manager/controller_test.go
@@ -32,8 +32,8 @@ func ExampleNewOwnedResourceController() {
 
 	// the controller processes objects on the queue, but doesn't set up any
 	// informers by default.
-	controller := NewOwnedResourceController(klogr.New(), "my-controller", gvr, CtxQueue, registry, broadcaster, func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) {
-		// process object
+	controller := NewOwnedResourceController(klogr.New(), "my-controller", gvr, CtxQueue, registry, broadcaster, func(_ context.Context, gvr schema.GroupVersionResource, namespace, name string) {
+		fmt.Println("processing", gvr, namespace, name)
 	})
 
 	mgr := NewManager(ctrlmanageropts.RecommendedDebuggingOptions().DebuggingConfiguration, ":", broadcaster, eventSink)
@@ -54,7 +54,8 @@ func TestControllerQueueDone(t *testing.T) {
 	broadcaster := record.NewBroadcaster()
 	eventSink := &typedcorev1.EventSinkImpl{Interface: fake.NewSimpleClientset().CoreV1().Events("")}
 
-	controller := NewOwnedResourceController(klogr.New(), "my-controller", gvr, CtxQueue, registry, broadcaster, func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) {
+	controller := NewOwnedResourceController(klogr.New(), "my-controller", gvr, CtxQueue, registry, broadcaster, func(_ context.Context, gvr schema.GroupVersionResource, namespace, name string) {
+		fmt.Println("processing", gvr, namespace, name)
 	})
 
 	mgr := NewManager(ctrlmanageropts.RecommendedDebuggingOptions().DebuggingConfiguration, ":", broadcaster, eventSink)

--- a/pause/pause_test.go
+++ b/pause/pause_test.go
@@ -44,7 +44,7 @@ func ExampleNewPauseContextHandler() {
 		queueOperations.Key,
 		"example.com/paused",
 		ctxObject,
-		func(ctx context.Context, patch *MyObject) error {
+		func(_ context.Context, _ *MyObject) error {
 			// update status
 			return nil
 		},
@@ -184,7 +184,7 @@ func TestPauseHandler(t *testing.T) {
 			ctrls := &fake.FakeInterface{}
 			patchCalled := false
 
-			patchStatus := func(ctx context.Context, patch *MyObject) error {
+			patchStatus := func(_ context.Context, patch *MyObject) error {
 				patchCalled = true
 
 				if tt.patchError != nil {
@@ -209,7 +209,7 @@ func TestPauseHandler(t *testing.T) {
 			ctx = ctxMyObject.WithValue(ctx, tt.obj)
 			var called handler.Key
 
-			NewPauseContextHandler(queueOps.Key, PauseLabelKey, ctxMyObject, patchStatus, handler.ContextHandlerFunc(func(ctx context.Context) {
+			NewPauseContextHandler(queueOps.Key, PauseLabelKey, ctxMyObject, patchStatus, handler.ContextHandlerFunc(func(_ context.Context) {
 				called = nextKey
 			})).Handle(ctx)
 

--- a/queue/controls_test.go
+++ b/queue/controls_test.go
@@ -28,7 +28,7 @@ func ExampleNewOperations() {
 	}, cancel)
 
 	// typically called from a handler
-	handler.NewHandlerFromFunc(func(ctx context.Context) {
+	handler.NewHandlerFromFunc(func(_ context.Context) {
 		// do some work
 		operations.Done()
 	}, "example").Handle(ctx)
@@ -60,7 +60,7 @@ func ExampleNewQueueOperationsCtx() {
 	}, cancel))
 
 	// queue controls are passed via context
-	handler.NewHandlerFromFunc(func(ctx context.Context) {
+	handler.NewHandlerFromFunc(func(_ context.Context) {
 		// do some work
 		CtxQueue.Done()
 	}, "example").Handle(ctx)

--- a/static/controller.go
+++ b/static/controller.go
@@ -49,9 +49,9 @@ func NewStaticController[K bootstrap.KubeResourceObject](log logr.Logger, name s
 func (c *Controller[K]) Start(ctx context.Context, _ int) {
 	inf := c.fileInformerFactory.ForResource(c.staticClusterResource).Informer()
 	_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.handleStaticResource(ctx) },
-		UpdateFunc: func(_, obj interface{}) { c.handleStaticResource(ctx) },
-		DeleteFunc: func(obj interface{}) { c.handleStaticResource(ctx) },
+		AddFunc:    func(_ any) { c.handleStaticResource(ctx) },
+		UpdateFunc: func(_, _ any) { c.handleStaticResource(ctx) },
+		DeleteFunc: func(_ any) { c.handleStaticResource(ctx) },
 	})
 	if err != nil {
 		panic("failed to add handlers: " + err.Error())


### PR DESCRIPTION
and prefix the panicing versions with Must*.

The old methods are still there, but labelled `Deprecated`.