### PR TITLE
add `finalizer` package to help with finalizing objects

### DIFF
--- a/finalizer/finalizer.go
+++ b/finalizer/finalizer.go
@@ -1,0 +1,110 @@
+// Package finalizer provides utilities for managing Kubernetes finalizers in
+// controller applications.
+//
+// The core functions GetAddFunc and GetRemoveFunc return functions that can
+// add or remove finalizers from Kubernetes objects. These use get-modify-write
+// instead of apply/patch operations to ensure they cannot recreate objects
+// that have been marked for deletion.
+//
+// The SetFinalizerHandler provides a handler that automatically adds
+// finalizers to objects that don't already have them, excluding objects
+// with deletion timestamps.
+package finalizer
+
+import (
+	"context"
+
+	"golang.org/x/exp/slices"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/authzed/controller-idioms/component"
+	"github.com/authzed/controller-idioms/typed"
+)
+
+type (
+	AddFunc[K component.KubeObject]    func(ctx context.Context, nn types.NamespacedName) (K, error)
+	RemoveFunc[K component.KubeObject] func(ctx context.Context, nn types.NamespacedName) (K, error)
+)
+
+// GetAddFunc returns a function that does a get-modify-write instead of an apply, so that it can't accidentally
+// re-create a deleted object (apply does an upsert).
+func GetAddFunc[K component.KubeObject](client dynamic.Interface, gvr schema.GroupVersionResource, finalizer, fieldManager string) AddFunc[K] {
+	return func(ctx context.Context, nn types.NamespacedName) (K, error) {
+		// get latest object
+		u, err := client.Resource(gvr).Namespace(nn.Namespace).Get(ctx, nn.Name, metav1.GetOptions{})
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+		obj, err := typed.UnstructuredObjToTypedObj[K](u)
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+
+		if slices.Contains(obj.GetFinalizers(), finalizer) || obj.GetDeletionTimestamp() != nil {
+			return obj, nil
+		}
+
+		obj.SetFinalizers(append(obj.GetFinalizers(), finalizer))
+
+		finalized, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&obj)
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+
+		updated, err := client.Resource(gvr).Namespace(obj.GetNamespace()).Update(ctx, &unstructured.Unstructured{Object: finalized}, metav1.UpdateOptions{FieldManager: fieldManager})
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+
+		return typed.UnstructuredObjToTypedObj[K](updated)
+	}
+}
+
+// GetRemoveFunc returns a function that does a get-modify-write instead of an apply. Unlike when adding, this
+// won't be called in cases that could potentially re-create a deleted object, but we do it this way so that the field
+// manager operation matches what created the finalizer (`Update`).
+func GetRemoveFunc[K component.KubeObject](client dynamic.Interface, gvr schema.GroupVersionResource, finalizer, fieldManager string) RemoveFunc[K] {
+	return func(ctx context.Context, nn types.NamespacedName) (K, error) {
+		// get latest object
+		u, err := client.Resource(gvr).Namespace(nn.Namespace).Get(ctx, nn.Name, metav1.GetOptions{})
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+		obj, err := typed.UnstructuredObjToTypedObj[K](u)
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+
+		finalizerIdx := slices.Index(obj.GetFinalizers(), finalizer)
+
+		if finalizerIdx == -1 || obj.GetDeletionTimestamp() == nil {
+			return obj, nil
+		}
+		obj.SetFinalizers(slices.Delete(obj.GetFinalizers(), finalizerIdx, finalizerIdx+1))
+
+		definalized, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&obj)
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+
+		updated, err := client.Resource(gvr).Namespace(obj.GetNamespace()).Update(ctx, &unstructured.Unstructured{Object: definalized}, metav1.UpdateOptions{FieldManager: fieldManager})
+		if err != nil {
+			var nilObj K
+			return nilObj, err
+		}
+
+		return typed.UnstructuredObjToTypedObj[K](updated)
+	}
+}

--- a/finalizer/finalizer_test.go
+++ b/finalizer/finalizer_test.go
@@ -1,0 +1,180 @@
+package finalizer_test
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/authzed/controller-idioms/finalizer"
+)
+
+func ExampleGetAddFunc() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a test object without a finalizer
+	testObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "MyObject",
+			"metadata": map[string]interface{}{
+				"name":      "test-object",
+				"namespace": "default",
+			},
+		},
+	}
+
+	// Create a fake dynamic client with the test object
+	scheme := runtime.NewScheme()
+	dynamicClient := fake.NewSimpleDynamicClient(scheme, testObj)
+
+	// Define the GVR for our resource
+	gvr := schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "myobjects",
+	}
+
+	// Create an add function for finalizers
+	addFunc := finalizer.GetAddFunc[*metav1.PartialObjectMetadata](
+		dynamicClient,
+		gvr,
+		"my-controller.example.com/finalizer",
+		"my-controller",
+	)
+
+	// Use the function to add a finalizer
+	result, err := addFunc(ctx, types.NamespacedName{
+		Name:      "test-object",
+		Namespace: "default",
+	})
+	if err != nil {
+		fmt.Printf("Error adding finalizer: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Finalizer added: %v\n", len(result.GetFinalizers()) > 0)
+	fmt.Printf("Finalizer name: %s\n", result.GetFinalizers()[0])
+
+	// Output: Finalizer added: true
+	// Finalizer name: my-controller.example.com/finalizer
+}
+
+func ExampleGetRemoveFunc() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := metav1.Now()
+
+	// Create a test object with a finalizer and deletion timestamp
+	testObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "MyObject",
+			"metadata": map[string]interface{}{
+				"name":      "test-object",
+				"namespace": "default",
+				"finalizers": []interface{}{
+					"my-controller.example.com/finalizer",
+				},
+				"deletionTimestamp": now.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+	}
+
+	// Create a fake dynamic client with the test object
+	scheme := runtime.NewScheme()
+	dynamicClient := fake.NewSimpleDynamicClient(scheme, testObj)
+
+	// Define the GVR for our resource
+	gvr := schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "myobjects",
+	}
+
+	// Create a remove function for finalizers
+	removeFunc := finalizer.GetRemoveFunc[*metav1.PartialObjectMetadata](
+		dynamicClient,
+		gvr,
+		"my-controller.example.com/finalizer",
+		"my-controller",
+	)
+
+	// Use the function to remove a finalizer
+	result, err := removeFunc(ctx, types.NamespacedName{
+		Name:      "test-object",
+		Namespace: "default",
+	})
+	if err != nil {
+		fmt.Printf("Error removing finalizer: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Finalizer removed: %v\n", len(result.GetFinalizers()) == 0)
+	fmt.Printf("Has deletion timestamp: %v\n", result.GetDeletionTimestamp() != nil)
+
+	// Output: Finalizer removed: true
+	// Has deletion timestamp: true
+}
+
+func ExampleGetAddFunc_alreadyHasFinalizer() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a test object that already has the finalizer
+	testObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "MyObject",
+			"metadata": map[string]interface{}{
+				"name":      "test-object",
+				"namespace": "default",
+				"finalizers": []interface{}{
+					"my-controller.example.com/finalizer",
+				},
+			},
+		},
+	}
+
+	// Create a fake dynamic client with the test object
+	scheme := runtime.NewScheme()
+	dynamicClient := fake.NewSimpleDynamicClient(scheme, testObj)
+
+	// Define the GVR for our resource
+	gvr := schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "myobjects",
+	}
+
+	// Create an add function for finalizers
+	addFunc := finalizer.GetAddFunc[*metav1.PartialObjectMetadata](
+		dynamicClient,
+		gvr,
+		"my-controller.example.com/finalizer",
+		"my-controller",
+	)
+
+	// Use the function - it should be a no-op since finalizer already exists
+	result, err := addFunc(ctx, types.NamespacedName{
+		Name:      "test-object",
+		Namespace: "default",
+	})
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Finalizer count: %d\n", len(result.GetFinalizers()))
+	fmt.Printf("Still has finalizer: %v\n", result.GetFinalizers()[0] == "my-controller.example.com/finalizer")
+
+	// Output: Finalizer count: 1
+	// Still has finalizer: true
+}

--- a/finalizer/set_finalizer.go
+++ b/finalizer/set_finalizer.go
@@ -1,0 +1,39 @@
+package finalizer
+
+import (
+	"context"
+
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/authzed/controller-idioms/component"
+	"github.com/authzed/controller-idioms/handler"
+	"github.com/authzed/controller-idioms/typedctx"
+)
+
+type ctxKey[K component.KubeObject] interface {
+	typedctx.SettableContext[K]
+	typedctx.MustValueContext[K]
+}
+
+type SetFinalizerHandler[K component.KubeObject] struct {
+	FinalizeableObjectCtxKey ctxKey[K]
+	Finalizer                string
+	AddFinalizer             AddFunc[K]
+	RequeueAPIErr            func(context.Context, error)
+
+	Next handler.Handler
+}
+
+func (s *SetFinalizerHandler[K]) Handle(ctx context.Context) {
+	obj := s.FinalizeableObjectCtxKey.MustValue(ctx)
+	if !slices.Contains(obj.GetFinalizers(), s.Finalizer) && obj.GetDeletionTimestamp() == nil {
+		db, err := s.AddFinalizer(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()})
+		if err != nil {
+			s.RequeueAPIErr(ctx, err)
+			return
+		}
+		ctx = s.FinalizeableObjectCtxKey.WithValue(ctx, db)
+	}
+	s.Next.Handle(ctx)
+}

--- a/finalizer/set_finalizer_test.go
+++ b/finalizer/set_finalizer_test.go
@@ -1,0 +1,275 @@
+package finalizer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/authzed/controller-idioms/handler"
+	"github.com/authzed/controller-idioms/typedctx"
+)
+
+func ExampleGetAddFunc() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a test object without a finalizer
+	testObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "MyObject",
+			"metadata": map[string]interface{}{
+				"name":      "my-object",
+				"namespace": "default",
+			},
+		},
+	}
+
+	// Create a fake dynamic client with a basic scheme
+	scheme := runtime.NewScheme()
+	dynamicClient := fake.NewSimpleDynamicClient(scheme, testObj)
+
+	// Define the GVR for our resource
+	gvr := schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "myobjects",
+	}
+
+	// Create an add function for finalizers
+	addFunc := GetAddFunc[*metav1.PartialObjectMetadata](
+		dynamicClient,
+		gvr,
+		"my-controller.example.com/finalizer",
+		"my-controller",
+	)
+
+	// Use the function to add a finalizer
+	result, err := addFunc(ctx, types.NamespacedName{
+		Name:      "my-object",
+		Namespace: "default",
+	})
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+		return
+	}
+
+	fmt.Printf("Has finalizer: %v", len(result.GetFinalizers()) > 0)
+
+	// Output: Has finalizer: true
+}
+
+func ExampleGetRemoveFunc() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := metav1.Now()
+
+	// Create a test object with a finalizer and deletion timestamp
+	testObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "MyObject",
+			"metadata": map[string]interface{}{
+				"name":      "my-object",
+				"namespace": "default",
+				"finalizers": []interface{}{
+					"my-controller.example.com/finalizer",
+				},
+				"deletionTimestamp": now.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+	}
+
+	// Create a fake dynamic client with a basic scheme
+	scheme := runtime.NewScheme()
+	dynamicClient := fake.NewSimpleDynamicClient(scheme, testObj)
+
+	// Define the GVR for our resource
+	gvr := schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "myobjects",
+	}
+
+	// Create a remove function for finalizers
+	removeFunc := GetRemoveFunc[*metav1.PartialObjectMetadata](
+		dynamicClient,
+		gvr,
+		"my-controller.example.com/finalizer",
+		"my-controller",
+	)
+
+	// Use the function to remove a finalizer
+	result, err := removeFunc(ctx, types.NamespacedName{
+		Name:      "my-object",
+		Namespace: "default",
+	})
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+		return
+	}
+
+	fmt.Printf("Finalizer removed: %v", len(result.GetFinalizers()) == 0)
+
+	// Output: Finalizer removed: true
+}
+
+func ExampleSetFinalizerHandler() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create context key for our object
+	CtxObject := typedctx.WithDefault[*metav1.PartialObjectMetadata](nil)
+
+	// Mock object without finalizer
+	obj := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-object",
+			Namespace: "default",
+		},
+	}
+
+	// Add object to context
+	ctx = CtxObject.WithValue(ctx, obj)
+
+	// Create the handler
+	handler := &SetFinalizerHandler[*metav1.PartialObjectMetadata]{
+		FinalizeableObjectCtxKey: CtxObject,
+		Finalizer:                "my-controller.example.com/finalizer",
+		AddFinalizer: func(_ context.Context, nn types.NamespacedName) (*metav1.PartialObjectMetadata, error) {
+			// Mock successful finalizer addition
+			return &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       nn.Name,
+					Namespace:  nn.Namespace,
+					Finalizers: []string{"my-controller.example.com/finalizer"},
+				},
+			}, nil
+		},
+		RequeueAPIErr: func(_ context.Context, err error) {
+			fmt.Printf("Requeue due to error: %v", err)
+		},
+		Next: handler.NewHandlerFromFunc(func(_ context.Context) {
+			fmt.Println("Processing next handler")
+		}, "next"),
+	}
+
+	// Execute the handler
+	handler.Handle(ctx)
+
+	// Output: Processing next handler
+}
+
+func TestSetFinalizer(t *testing.T) {
+	t.Parallel()
+
+	CtxObject := typedctx.WithDefault[*metav1.PartialObjectMetadata](nil)
+
+	now := metav1.Now()
+	var nextKey handler.Key = "next"
+	tests := []struct {
+		name string
+
+		obj      *metav1.PartialObjectMetadata
+		patchErr error
+
+		expectNext          handler.Key
+		expectPatch         bool
+		expectRequeueAPIErr bool
+	}{
+		{
+			name: "missing finalizer",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+			},
+			expectPatch: true,
+			expectNext:  nextKey,
+		},
+		{
+			name: "has finalizer",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Namespace:  "test",
+					Finalizers: []string{"finalizer"},
+				},
+			},
+			expectNext: nextKey,
+		},
+		{
+			name: "doesn't add to deleted object",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test",
+					Namespace:         "test",
+					DeletionTimestamp: &now,
+				},
+			},
+			expectPatch: false,
+			expectNext:  nextKey,
+		},
+		{
+			name: "patch err",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+			},
+			expectPatch:         true,
+			patchErr:            fmt.Errorf("error"),
+			expectRequeueAPIErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			patchCalled := false
+			requeueCalled := false
+
+			ctx := t.Context()
+			ctx = CtxObject.WithValue(ctx, tt.obj)
+
+			var called handler.Key
+			h := &SetFinalizerHandler[*metav1.PartialObjectMetadata]{
+				AddFinalizer: func(_ context.Context, nn types.NamespacedName) (*metav1.PartialObjectMetadata, error) {
+					patchCalled = true
+					return &metav1.PartialObjectMetadata{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       nn.Name,
+							Namespace:  nn.Namespace,
+							Finalizers: []string{"finalizer"},
+						},
+					}, tt.patchErr
+				},
+				FinalizeableObjectCtxKey: CtxObject,
+				Finalizer:                "finalizer",
+				RequeueAPIErr: func(_ context.Context, _ error) {
+					requeueCalled = true
+				},
+				Next: handler.NewHandlerFromFunc(func(_ context.Context) {
+					called = nextKey
+				}, "next"),
+			}
+			h.Handle(ctx)
+
+			require.Equal(t, tt.expectPatch, patchCalled)
+			require.Equal(t, tt.expectNext, called)
+			require.Equal(t, tt.expectRequeueAPIErr, requeueCalled)
+		})
+	}
+}


### PR DESCRIPTION
We've been using this package internally for a while; it's been stable and is better shared here.

I plan to use this in other (open source) operators, so I want it to be available. I'll update internal references to use this once merged.

Fixes #38 