### PR TITLE
add deterministic simulated Kubernetes  (dsk) package

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Build & Test"
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "main"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Lint"
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "!dependabot/*"

--- a/analyzers/asynchandler/asynchandler.go
+++ b/analyzers/asynchandler/asynchandler.go
@@ -1,0 +1,129 @@
+package asynchandler
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "asynchandler",
+	Doc: "reports go statements inside Kubernetes event handler callbacks that may spawn " +
+		"queue.Add calls invisible to DSK handler tracking. " +
+		"Detects cache.ResourceEventHandlerFuncs and cache.ResourceEventHandlerDetailedFuncs " +
+		"composite literals, and named types whose OnAdd/OnUpdate/OnDelete methods implement " +
+		"cache.ResourceEventHandler.",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	rehInterface := resourceEventHandlerInterface(pass)
+
+	nodeFilter := []ast.Node{
+		(*ast.CompositeLit)(nil),
+		(*ast.FuncDecl)(nil),
+	}
+
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		switch node := n.(type) {
+		case *ast.CompositeLit:
+			if !isKnownHandlerFuncsType(pass, node) {
+				return
+			}
+			for _, elt := range node.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				ident, ok := kv.Key.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				if ident.Name != "AddFunc" && ident.Name != "UpdateFunc" && ident.Name != "DeleteFunc" {
+					continue
+				}
+				fn, ok := kv.Value.(*ast.FuncLit)
+				if !ok {
+					continue
+				}
+				checkBodyForGoStmts(pass, fn.Body)
+			}
+
+		case *ast.FuncDecl:
+			if rehInterface == nil || !isHandlerMethod(pass, node, rehInterface) {
+				return
+			}
+			if node.Body != nil {
+				checkBodyForGoStmts(pass, node.Body)
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+// isKnownHandlerFuncsType reports whether cl is a composite literal of
+// cache.ResourceEventHandlerFuncs or cache.ResourceEventHandlerDetailedFuncs.
+func isKnownHandlerFuncsType(pass *analysis.Pass, cl *ast.CompositeLit) bool {
+	t := pass.TypesInfo.TypeOf(cl)
+	if t == nil {
+		return false
+	}
+	s := t.String()
+	return s == "k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs" ||
+		s == "k8s.io/client-go/tools/cache.ResourceEventHandlerDetailedFuncs"
+}
+
+// resourceEventHandlerInterface returns the *types.Interface for
+// cache.ResourceEventHandler from the analyzed package's imports, or nil.
+func resourceEventHandlerInterface(pass *analysis.Pass) *types.Interface {
+	for _, pkg := range pass.Pkg.Imports() {
+		if pkg.Path() == "k8s.io/client-go/tools/cache" {
+			obj := pkg.Scope().Lookup("ResourceEventHandler")
+			if obj == nil {
+				return nil
+			}
+			intf, ok := obj.Type().Underlying().(*types.Interface)
+			if !ok {
+				return nil
+			}
+			return intf
+		}
+	}
+	return nil
+}
+
+// isHandlerMethod reports whether fn is an OnAdd, OnUpdate, or OnDelete method
+// on a type that implements cache.ResourceEventHandler.
+func isHandlerMethod(pass *analysis.Pass, fn *ast.FuncDecl, rehInterface *types.Interface) bool {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return false
+	}
+	name := fn.Name.Name
+	if name != "OnAdd" && name != "OnUpdate" && name != "OnDelete" {
+		return false
+	}
+	recvType := pass.TypesInfo.TypeOf(fn.Recv.List[0].Type)
+	if recvType == nil {
+		return false
+	}
+	return types.Implements(recvType, rehInterface) ||
+		types.Implements(types.NewPointer(recvType), rehInterface)
+}
+
+func checkBodyForGoStmts(pass *analysis.Pass, body *ast.BlockStmt) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok {
+			return true
+		}
+		pass.Reportf(goStmt.Pos(), "go statement in event handler dispatches work outside DSK handler tracking; queue.Add calls in the goroutine will not be observed by Flush()")
+		return false
+	})
+}

--- a/analyzers/asynchandler/asynchandler_test.go
+++ b/analyzers/asynchandler/asynchandler_test.go
@@ -1,0 +1,14 @@
+package asynchandler_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/authzed/controller-idioms/analyzers/asynchandler"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, asynchandler.Analyzer, "example")
+}

--- a/analyzers/asynchandler/cmd/asynchandler/main.go
+++ b/analyzers/asynchandler/cmd/asynchandler/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/authzed/controller-idioms/analyzers/asynchandler"
+)
+
+func main() {
+	singlechecker.Main(asynchandler.Analyzer)
+}

--- a/analyzers/asynchandler/testdata/src/example/example.go
+++ b/analyzers/asynchandler/testdata/src/example/example.go
@@ -1,0 +1,141 @@
+package example
+
+import (
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func SyncHandler(q workqueue.Interface) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			q.Add(obj) // ok: synchronous
+		},
+	}
+}
+
+func AsyncHandler(q workqueue.Interface) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			go func() { // want "go statement in event handler"
+				q.Add(obj)
+			}()
+		},
+	}
+}
+
+// Task 2: Positive test cases
+
+func AsyncDirectGo(q workqueue.Interface) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			go q.Add(obj) // want "go statement in event handler"
+		},
+	}
+}
+
+type fakeInformer struct{}
+
+func (fakeInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func DirectAddEventHandler(inf fakeInformer, q workqueue.Interface) {
+	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			go q.Add(obj) // want "go statement in event handler"
+		},
+	})
+}
+
+func NestedGo(q workqueue.Interface) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			go func() { // want "go statement in event handler"
+				helper(q, obj)
+			}()
+		},
+	}
+}
+
+func helper(q workqueue.Interface, obj any) {
+	q.Add(obj)
+}
+
+// ResourceEventHandlerDetailedFuncs with go stmt — should report.
+func AsyncDetailedHandler(q workqueue.Interface) cache.ResourceEventHandlerDetailedFuncs {
+	return cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj any, isInInitialList bool) {
+			go q.Add(obj) // want "go statement in event handler"
+		},
+	}
+}
+
+// Sync DetailedFuncs — no diagnostic.
+func SyncDetailedHandler(q workqueue.Interface) cache.ResourceEventHandlerDetailedFuncs {
+	return cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj any, isInInitialList bool) {
+			q.Add(obj)
+		},
+	}
+}
+
+// Struct implementing ResourceEventHandler with go stmt in OnAdd — should report.
+type asyncHandlerImpl struct {
+	q workqueue.Interface
+}
+
+func (h *asyncHandlerImpl) OnAdd(obj any, isInInitialList bool) {
+	go h.q.Add(obj) // want "go statement in event handler"
+}
+
+func (h *asyncHandlerImpl) OnUpdate(oldObj, newObj any) {
+	h.q.Add(newObj) // ok: synchronous
+}
+
+func (h *asyncHandlerImpl) OnDelete(obj any) {
+	h.q.Add(obj) // ok: synchronous
+}
+
+// Struct implementing ResourceEventHandler with sync methods — no diagnostic.
+type syncHandlerImpl struct {
+	q workqueue.Interface
+}
+
+func (h *syncHandlerImpl) OnAdd(obj any, isInInitialList bool) {
+	h.q.Add(obj)
+}
+
+func (h *syncHandlerImpl) OnUpdate(oldObj, newObj any) {
+	h.q.Add(newObj)
+}
+
+func (h *syncHandlerImpl) OnDelete(obj any) {
+	h.q.Add(obj)
+}
+
+// Task 3: Negative test cases
+
+// Synchronous Add on all three fields — no diagnostic.
+func SyncAllFields(q workqueue.Interface) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			q.Add(obj)
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			q.Add(newObj)
+		},
+		DeleteFunc: func(obj any) {
+			q.Add(obj)
+		},
+	}
+}
+
+// Go statement outside a handler — no diagnostic.
+func NotAHandler(q workqueue.Interface) {
+	go q.Add("key")
+}
+
+// ResourceEventHandlerFuncs with nil fields — no diagnostic.
+func NilFields() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{}
+}

--- a/analyzers/asynchandler/testdata/src/k8s.io/client-go/tools/cache/types.go
+++ b/analyzers/asynchandler/testdata/src/k8s.io/client-go/tools/cache/types.go
@@ -1,0 +1,33 @@
+package cache
+
+type ResourceEventHandler interface {
+	OnAdd(obj any, isInInitialList bool)
+	OnUpdate(oldObj, newObj any)
+	OnDelete(obj any)
+}
+
+type ResourceEventHandlerFuncs struct {
+	AddFunc    func(obj any)
+	UpdateFunc func(oldObj, newObj any)
+	DeleteFunc func(obj any)
+}
+
+func (r ResourceEventHandlerFuncs) OnAdd(obj any, isInInitialList bool) {}
+func (r ResourceEventHandlerFuncs) OnUpdate(oldObj, newObj any)         {}
+func (r ResourceEventHandlerFuncs) OnDelete(obj any)                    {}
+
+type ResourceEventHandlerDetailedFuncs struct {
+	AddFunc    func(obj any, isInInitialList bool)
+	UpdateFunc func(oldObj, newObj any)
+	DeleteFunc func(obj any, tombstone bool)
+}
+
+func (r ResourceEventHandlerDetailedFuncs) OnAdd(obj any, isInInitialList bool) {}
+func (r ResourceEventHandlerDetailedFuncs) OnUpdate(oldObj, newObj any)         {}
+func (r ResourceEventHandlerDetailedFuncs) OnDelete(obj any)                    {}
+
+type ResourceEventHandlerRegistration interface{}
+
+type SharedIndexInformer interface {
+	AddEventHandler(handler ResourceEventHandler) (ResourceEventHandlerRegistration, error)
+}

--- a/analyzers/asynchandler/testdata/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/analyzers/asynchandler/testdata/src/k8s.io/client-go/util/workqueue/queue.go
@@ -1,0 +1,18 @@
+package workqueue
+
+import "time"
+
+type Interface interface {
+	Add(item any)
+	Get() (item any, shutdown bool)
+	Done(item any)
+	Len() int
+	ShutDown()
+	ShuttingDown() bool
+}
+
+type RateLimitingInterface interface {
+	Interface
+	AddRateLimited(item any)
+	AddAfter(item any, duration time.Duration)
+}

--- a/dsk/README.md
+++ b/dsk/README.md
@@ -1,0 +1,224 @@
+# dsk — Deterministic Simulated Kubernetes
+
+DSK is an in-process Go simulation layer for testing Kubernetes controllers. It sits between a controller and a real Kubernetes client (envtest, kind, or a fake), mediating all API calls. The central abstraction is the **tick** — a deterministic delta cycle that controls exactly when watch events are delivered to controllers.
+
+## Why
+
+Some classes of controller bugs are notoriously hard to test with standard approaches:
+
+- **Convergence**: tick until `IsSteady()` or fail at a max-tick limit, catching both slow convergence (assert on tick count) and infinite requeue loops (never reaches steady state)
+- **Ordering races between controllers**: `Buffer()` returns pending events as a slice; tests can explicitly deliver them in any order or use a property-testing library to enumerate all permutations
+
+DSK makes these testable:
+
+1. **Steady-state detection**: tick until `IsSteady()` returns true, or fail if you hit a max-tick limit.
+2. **Event ordering control**: `Buffer()` gives you all pending events as a plain slice; `Flush()` delivers any subset. Test both orderings explicitly, or feed the slice to a property testing library to generate all permutations.
+3. **Fault injection** — inject errors or delays on specific verbs/resources without modifying controller code.
+
+## How it works
+
+DSK wraps `dynamic.Interface` and `kubernetes.Interface`. Writes and reads pass through to the underlying client immediately. `Watch` calls are intercepted: events from upstream are buffered inside DSK and not forwarded to the controller until `Flush` is called.
+
+Cooperative tick completion uses a queue wrapper (`WrapQueue`) that tracks items between `Get()` and `Done()` during each tick. `Flush` returns only after every in-flight item has called `Done()`. Steady-state detection (`IsSteady()`) additionally checks that the underlying queue is fully drained.
+
+```text
+test code
+   │
+   ├── d.Dynamic(fake)              ← fake client (reactor path)
+   ├── d.DynamicFromConfig(cfg)     ← real client (transport path)
+   ├── d.Typed(fake)                ← fake typed client (reactor path)
+   ├── d.TypedFromConfig(cfg)       ← real typed client (transport path)
+   ├── d.WrapQueue(q)               ← wraps workqueue.RateLimitingInterface
+   └── dsk.NewRegistry(d)           ← wraps typed.Registry with handler tracking
+          │
+    DSK tick engine                  ← buffers watch events, tracks queue completion
+          │
+    underlying client                ← envtest / kind / fake
+```
+
+## Inspiration
+
+The tick/delta-cycle model is borrowed from VHDL simulation. In VHDL, a simulator advances time in discrete steps; within each step, signal changes propagate through zero-time "delta cycles" until the design reaches quiescence. DSK applies the same idea to controller testing: a `Tick` is a delta cycle in which all pending watch events are delivered and all resulting reconciles complete before the next tick begins. This gives controller tests the same reproducibility that hardware engineers rely on for gate-level simulation. Sigasi's [VHDL's crown jewel](https://www.sigasi.com/opinion/jan/vhdls-crown-jewel/) is a good primer on the concept.
+
+## Installation
+
+```sh
+go get github.com/authzed/controller-idioms/dsk
+```
+
+All tests using DSK must be run with the `dsk` build tag:
+
+```sh
+go test -tags dsk ./...
+```
+
+## Quick start
+
+```go
+import (
+    "github.com/authzed/controller-idioms/client/fake"
+    dsk "github.com/authzed/controller-idioms/dsk"
+    "k8s.io/apimachinery/pkg/runtime"
+    "k8s.io/client-go/util/workqueue"
+)
+
+func TestReachSteadyState(t *testing.T) {
+    d := dsk.New(t)
+
+    // Fake client path — works for all resource types, no per-type boilerplate.
+    client := d.Dynamic(fake.NewClient(runtime.NewScheme()))
+    q := d.WrapQueue(workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()))
+    defer q.ShutDown()
+
+    go myController.Run(t.Context(), client, q)
+
+    // Trigger an event — writes pass through immediately; the watch event is buffered.
+    // Tick automatically waits for write-triggered watch events to arrive before flushing.
+    createResource(client, myResource)
+
+    d.TickUntilSteady(20)
+}
+```
+
+For real clusters (envtest, kind), use `DynamicFromConfig` or `TypedFromConfig` instead:
+
+```go
+// Real cluster path — wraps the HTTP transport, covers all resource types.
+client, err := d.DynamicFromConfig(restConfig)
+typedClient, err := d.TypedFromConfig(restConfig)
+```
+
+## Core API
+
+### `DSK`
+
+```go
+d := dsk.New(t)                              // one per test scenario
+client := d.Dynamic(fake)                    // fake dynamic.Interface (reactor path)
+client, err := d.DynamicFromConfig(cfg)      // real dynamic client (transport path)
+client := d.Typed(fake)                      // fake kubernetes.Interface (reactor path)
+client, err := d.TypedFromConfig(cfg)        // real typed client (transport path)
+q      := d.WrapQueue(q)                     // wrap workqueue.RateLimitingInterface
+q      := dsk.WrapTypedQueue(d, q)           // wrap workqueue.TypedRateLimitingInterface[T]
+                                             // (package-level function; Go does not yet support generic methods)
+
+buf := d.Buffer()                       // []PendingEvent — snapshot of buffered events
+d.WaitForEvents(n)                      // block until ≥n events are buffered (no prior write needed)
+d.Flush(buf)                            // deliver events, wait for reconciles
+d.Tick()                                // flush all buffered events (= Flush(Buffer()))
+d.Ticks(n)                              // Tick n times
+d.TickUntilSteady(n)                    // Tick up to n times; tb.Fatal if not steady
+ok  := d.IsSteady()                    // true when buffer empty and all queues idle
+```
+
+### `PendingEvent`
+
+`Buffer()` returns `[]PendingEvent`. Each value embeds `watch.Event` (giving access to `Type` and `Object`) and carries an unexported routing pointer. Slices of `PendingEvent` can be filtered, sorted, or passed directly to `pgregory.net/rapid` generators.
+
+Pass values from `Buffer()` directly to `Flush()` — do not reconstruct them.
+
+### Fault injection
+
+```go
+h := d.InjectFault(
+    dsk.ErrorFault(errors.NewServiceUnavailable("simulated outage")).
+        OnVerb("patch").
+        OnResource(deploymentGVR),
+)
+// ... run test ...
+d.RemoveFault(h)      // or d.ClearFaults() to remove all
+```
+
+`ErrorFault` returns an error for matching calls. `DelayFault` adds latency before forwarding the call. Both implement `FaultBuilder` with chainable selectors:
+
+| Selector | Matches on |
+|---|---|
+| `OnVerb(verb)` | HTTP verb: `"get"`, `"list"`, `"watch"`, `"create"`, `"update"`, `"patch"`, `"delete"` |
+| `OnResource(gvr)` | `schema.GroupVersionResource` |
+| `OnNamespace(ns)` | namespace string |
+| `OnName(name)` | object name |
+
+Unset selectors match everything. Selectors compose with AND.
+
+## Use cases
+
+### Steady-state detection
+
+Tick until `IsSteady()` or fail at a max-tick limit. The test fails clearly instead of hanging.
+
+```go
+d.TickUntilSteady(20)
+```
+
+### Event ordering (manual)
+
+```go
+events := d.Buffer()
+
+// Deliver controller A's events first, then B's
+d.Flush(filterFor(events, controllerA))
+d.Flush(filterFor(events, controllerB))
+assertInvariant(t, client)
+
+// Then test the reverse ordering
+d.Flush(filterFor(events, controllerB))
+d.Flush(filterFor(events, controllerA))
+assertInvariant(t, client)
+```
+
+### Property testing with `pgregory.net/rapid`
+
+`Buffer()` returns a plain Go slice, making it a first-class citizen in property testing:
+
+```go
+rapid.Check(t, func(t *rapid.T) {
+    d := dsk.New(t)
+    go controllerA.Run(t.Context(), d.Dynamic(underlying), d.WrapQueue(qA))
+    go controllerB.Run(t.Context(), d.Dynamic(underlying), d.WrapQueue(qB))
+
+    // Write through the DSK-wrapped client so Buffer() waits for the
+    // watch event to arrive before returning — no sleep needed.
+    createSharedResource(d.Dynamic(underlying), ...)
+
+    // rapid generates a random ordering of buffered events
+    ordering := rapid.SliceOf(rapid.SampledFrom(d.Buffer())).Draw(t, "ordering")
+    d.Flush(ordering)
+
+    assertInvariant(t, underlying)
+})
+```
+
+## Client coverage
+
+`d.Dynamic()` and `d.Typed()` intercept Watch calls for **all resource types**:
+
+- **Fake clients** (those satisfying the reactor interface, e.g. `fake.NewClient(scheme)`, `k8sfake.NewSimpleClientset()`): a universal watch reactor and write observer are installed on the underlying client. No per-type wrapper code is needed.
+- **Real clients** (`DynamicFromConfig`, `TypedFromConfig`): the HTTP `RoundTripper` is wrapped at the config level, so all group-version-resource paths are intercepted transparently.
+
+`Apply` and `ApplyStatus` are also tracked on fake clients via a thin wrapper that calls `preExpectWrite`/`upgradeExpect` around the operation.
+
+## Limitations
+
+- **In-process only.** DSK mediates calls to an existing Kubernetes client — it does not run its own API server. This is by design: DSK works with whatever client your controller already uses (envtest, kind, fake), so there is nothing new to deploy or configure.
+- **Rate-limiter delay heap is not visible.** Items queued via `AddRateLimited` or `AddAfter(d > 0)` that have not yet cleared the delay heap are not counted by `Len()`. `IsSteady()` may return a transient false positive until the delay expires. Running tests inside a `testing/synctest` bubble and calling `synctest.Wait()` advances virtual time past all pending delays, making `IsSteady()` reflect true quiescence.
+
+## Static analysis
+
+The `asynchandler` analyzer detects `go` statements inside Kubernetes event handler callbacks (`AddFunc`, `UpdateFunc`, `DeleteFunc` in `cache.ResourceEventHandlerFuncs`). Goroutines spawned from a handler body can call `queue.Add()` after the handler returns, making those enqueues invisible to DSK's handler tracking.
+
+Run it standalone:
+
+```sh
+go build -o asynchandler ./analyzers/asynchandler/cmd/asynchandler
+go vet -vettool=./asynchandler -tags dsk ./...
+```
+
+Or use it programmatically in a test:
+
+```go
+import "github.com/authzed/controller-idioms/analyzers/asynchandler"
+
+func TestNoAsyncHandlers(t *testing.T) {
+    // use analysistest.Run or multichecker
+}
+```

--- a/dsk/doc.go
+++ b/dsk/doc.go
@@ -1,0 +1,13 @@
+//go:build dsk
+
+// Package dsk provides deterministic simulated Kubernetes (DSK) for controller
+// testing. It wraps Kubernetes clients and informers to buffer watch events,
+// delivering them only when the test calls Tick or Flush. This makes
+// controller reconcile loops deterministic and eliminates timing-sensitive
+// polling in tests.
+//
+// All DSK types and functions are only available when compiled with -tags dsk.
+// Importing this package without the build tag produces a build error because
+// all source files carry the tag. Test files that import dsk must also carry
+// the build tag.
+package dsk

--- a/dsk/dsk.go
+++ b/dsk/dsk.go
@@ -1,0 +1,333 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// TB is the subset of testing.TB that DSK requires. *testing.T, *testing.B,
+// and *rapid.T all satisfy it. The full testing.TB interface is intentionally
+// not required so that property-testing libraries whose T types implement only
+// a narrower set of methods (e.g. pgregory.net/rapid) work without adaptation.
+type TB interface {
+	Context() context.Context
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+// helperMarker is an optional extension of TB. *testing.T implements it;
+// rapid.T does not. DSK calls Helper() when available so that test failures
+// are attributed to the call site rather than inside DSK itself.
+type helperMarker interface {
+	Helper()
+}
+
+// PendingEvent pairs a watch.Event with its destination.
+// The dest, gvr, and id fields are unexported; callers access the event via the embedded watch.Event.
+// PendingEvent values from Buffer() are valid inputs to Flush().
+type PendingEvent struct {
+	watch.Event
+	dest eventSink
+	gvr  schema.GroupVersionResource
+	id   uint64
+}
+
+// DSK is the simulation coordinator. Create one per test scenario with New().
+type DSK struct {
+	tb     TB
+	engine *engine
+	faults *faultSet
+}
+
+// helper marks the calling DSK method as a test helper when the underlying TB
+// supports it (i.e. when it implements helperMarker). This makes test failure
+// output point to the caller of the DSK method rather than inside DSK itself.
+func (d *DSK) helper() {
+	if h, ok := d.tb.(helperMarker); ok {
+		h.Helper()
+	}
+}
+
+// New creates a new DSK instance bound to the given test.
+//
+// tb is required: DSK uses tb.Context() for lifecycle management and tb.Fatal
+// for error reporting, making the API error-free at the call site. This makes
+// DSK intentionally test-only; there is no production-use path.
+//
+// tb must implement the DSK TB interface: Context(), Fatal(), and Fatalf().
+// *testing.T, *testing.B, and *rapid.T (pgregory.net/rapid) all qualify.
+//
+// For controllers that cannot use WrapQueue (external or legacy code without
+// access to the workqueue), cooperative tick completion is not currently
+// supported. Use WrapQueue where possible; it is the only supported completion
+// mechanism.
+func New(tb TB, opts ...Option) *DSK {
+	// Initialize tb.Context() and eagerly access its Done channel before any
+	// testing/synctest bubble is entered. context.cancelCtx.Done() is lazily
+	// initialized: the first call creates the underlying chan struct{}. If this
+	// happens inside a synctest bubble, the channel becomes a "synctest channel"
+	// and the runtime panics when it is later closed by the test cleanup from
+	// outside the bubble. Calling Done() here ensures the channel is allocated
+	// on the real heap before the bubble starts.
+	_ = tb.Context().Done()
+	eng := newEngine()
+	eng.tb = tb
+	d := &DSK{
+		tb:     tb,
+		engine: eng,
+		faults: newFaultSet(),
+	}
+	for _, o := range opts {
+		o(d)
+	}
+	return d
+}
+
+// Option configures a DSK instance.
+type Option func(*DSK)
+
+// WithFaults sets initial faults on the DSK instance.
+func WithFaults(faults ...Fault) Option {
+	return func(d *DSK) {
+		for _, f := range faults {
+			d.faults.add(f)
+		}
+	}
+}
+
+// Dynamic returns a client that buffers watch events until Flush is called.
+// Supports fake clients (installs reactors). For real HTTP clients use DynamicFromConfig.
+func (d *DSK) Dynamic(underlying dynamic.Interface) dynamic.Interface {
+	if r, ok := underlying.(reactable); ok {
+		installReactors(d.tb.Context(), r, d.engine, d.faults, d.tb)
+		return wrapApply(underlying, d.engine, r.Tracker(), d.faults)
+	}
+	d.tb.Fatalf("dsk: unsupported dynamic.Interface; for real clients use d.DynamicFromConfig(cfg)")
+	return nil
+}
+
+// DynamicFromConfig creates a dynamic client from cfg with DSK watch buffering
+// and write RV tracking. Use this for real Kubernetes clusters (envtest, kind).
+// For fake clients, use Dynamic(fake).
+func (d *DSK) DynamicFromConfig(cfg *rest.Config) (dynamic.Interface, error) {
+	cfgCopy := rest.CopyConfig(cfg)
+	cfgCopy.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &dskTransport{underlying: rt, engine: d.engine, faults: d.faults, tb: d.tb}
+	})
+	return dynamic.NewForConfig(cfgCopy)
+}
+
+// Typed instruments a kubernetes.Interface for DSK watch buffering and write
+// RV tracking.
+//
+// For fake clients (satisfying the reactable interface, e.g. *k8sfake.Clientset),
+// a watch reactor and write observer are installed on the existing client.
+// The original value is returned with reactors installed. No wrapper is needed
+// because k8sfake.Clientset does not bypass reactors for Apply/ApplyStatus.
+//
+// For real kubernetes clients, use TypedFromConfig instead.
+func (d *DSK) Typed(underlying kubernetes.Interface) kubernetes.Interface {
+	if r, ok := underlying.(reactable); ok {
+		installReactors(d.tb.Context(), r, d.engine, d.faults, d.tb)
+		return underlying
+	}
+	d.tb.Fatalf("dsk: unsupported kubernetes.Interface; for real clients use d.TypedFromConfig(cfg)")
+	return nil
+}
+
+// TypedFromConfig creates a typed Kubernetes client from cfg with DSK watch
+// buffering and write RV tracking. Use this for real Kubernetes clusters
+// (envtest, kind). For fake clients, use Typed(fake).
+func (d *DSK) TypedFromConfig(cfg *rest.Config) (kubernetes.Interface, error) {
+	cfgCopy := rest.CopyConfig(cfg)
+	cfgCopy.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &dskTransport{underlying: rt, engine: d.engine, faults: d.faults, tb: d.tb}
+	})
+	return kubernetes.NewForConfig(cfgCopy)
+}
+
+// WrapQueue wraps a work queue for cooperative tick completion.
+// The returned queue is a drop-in replacement for the original.
+// Register all controller queues before calling Tick or Flush.
+func (d *DSK) WrapQueue(q workqueue.RateLimitingInterface) workqueue.RateLimitingInterface {
+	wq := newWrappedQueue(q)
+	d.engine.registerQueue(wq)
+	return wq
+}
+
+// WrapTypedQueue wraps a generic typed work queue for cooperative tick completion.
+// Use this instead of WrapQueue when the controller uses
+// workqueue.TypedRateLimitingInterface[T] directly (e.g. TypedRateLimitingInterface[string]).
+// The returned queue is a drop-in replacement for the original.
+//
+// Note: WrapTypedQueue is a package-level function (not a method on *DSK) because
+// Go does not currently support generic methods. This will be addressable once
+// generic methods land in a future Go version; at that point WrapTypedQueue will
+// become d.WrapTypedQueue(q).
+func WrapTypedQueue[T comparable](d *DSK, q workqueue.TypedRateLimitingInterface[T]) workqueue.TypedRateLimitingInterface[T] {
+	wq := newTypedWrappedQueue(q)
+	d.engine.registerQueue(wq)
+	return wq
+}
+
+// WaitForEvents blocks until at least n events are present in the buffer, or
+// the test context is cancelled. Unlike Buffer, it does not require a preceding
+// write operation to have set up pendingRVs tracking.
+//
+// WaitForEvents uses sync.Cond.Wait internally, which is durably blocking for
+// testing/synctest. This makes it safe to call from within a synctest bubble
+// when waiting for events driven by external I/O (e.g. HTTP watch responses)
+// that would otherwise prevent synctest.Wait from returning.
+func (d *DSK) WaitForEvents(n int) {
+	d.helper()
+	if err := d.engine.waitForBufferCount(d.tb.Context(), n); err != nil {
+		d.tb.Fatal(err)
+	}
+}
+
+// Buffer waits for any write-triggered watch events to arrive, then returns the
+// full set of buffered events pending delivery. Returns plain []PendingEvent for
+// easy filtering and use with property testing libraries such as pgregory.net/rapid.
+func (d *DSK) Buffer() []PendingEvent {
+	d.helper()
+	if err := d.engine.waitForPendingRVs(d.tb.Context()); err != nil {
+		d.tb.Fatal(err)
+	}
+	raw := d.engine.snapshot()
+	out := make([]PendingEvent, len(raw))
+	for i, pe := range raw {
+		out[i] = PendingEvent{Event: pe.event, dest: pe.dest, gvr: pe.gvr, id: pe.id}
+	}
+	return out
+}
+
+// Flush delivers the given events to their watch streams and waits for all
+// triggered reconciles to complete before returning.
+//
+// events must be values returned by a prior call to Buffer(). Do not modify
+// the Event.Object field of returned PendingEvent values — removal matching
+// relies on object pointer identity, and re-constructing events bypasses that.
+//
+// Use Flush to control which events are delivered and in what order.
+// For simple cases, use Tick which flushes all buffered events.
+func (d *DSK) Flush(events []PendingEvent) {
+	d.helper()
+	if err := d.flush(d.tb.Context(), events); err != nil {
+		d.tb.Fatal(err)
+	}
+}
+
+func (d *DSK) flush(ctx context.Context, events []PendingEvent) error {
+	if len(events) > 0 && !d.engine.hasQueues() {
+		d.tb.Logf("dsk: Flush called with %d event(s) but no queues are registered via WrapQueue or WrapTypedQueue — controller reconciles will not be tracked and Flush will return immediately after delivering events", len(events))
+	}
+	raw := make([]pendingEvent, len(events))
+	for i, pe := range events {
+		if pe.dest == nil || pe.id == 0 {
+			return fmt.Errorf("dsk: Flush received a PendingEvent not returned by Buffer()")
+		}
+		raw[i] = pendingEvent{event: pe.Event, dest: pe.dest, gvr: pe.gvr, id: pe.id}
+	}
+	d.engine.removeFromBuffer(raw)
+	return d.engine.flush(ctx, raw)
+}
+
+// Tick flushes all currently buffered watch events and waits for all triggered
+// reconciles to complete. Equivalent to Flush(d.Buffer()).
+func (d *DSK) Tick() {
+	d.helper()
+	if err := d.tick(d.tb.Context()); err != nil {
+		d.tb.Fatal(err)
+	}
+}
+
+func (d *DSK) tick(ctx context.Context) error {
+	if err := d.engine.waitForPendingRVs(ctx); err != nil {
+		return err
+	}
+	raw := d.engine.snapshot()
+	events := make([]PendingEvent, len(raw))
+	for i, pe := range raw {
+		events[i] = PendingEvent{Event: pe.event, dest: pe.dest, gvr: pe.gvr, id: pe.id}
+	}
+	return d.flush(ctx, events)
+}
+
+// Ticks calls Tick n times.
+func (d *DSK) Ticks(n int) {
+	d.helper()
+	for range n {
+		d.Tick()
+	}
+}
+
+// TickUntilSteady ticks up to n times, returning after the first tick where
+// IsSteady is true. Calls tb.Fatal if steady state is not reached within n ticks.
+//
+// After each tick, TickUntilSteady waits for all registered queues to fully
+// drain before checking IsSteady. This handles items requeued within a tick
+// (e.g. via Add in a handler, or via AddAfter/Done dirty path): the second
+// processing round completes before the steady-state check, so a controller
+// that requeues once converges in a single tick rather than requiring n>1.
+// Queues that had no activity (no Add or Get calls) during the tick are not
+// waited on, so TickUntilSteady still exhausts its tick budget when the queue
+// has stuck items that are never processed.
+func (d *DSK) TickUntilSteady(n int) {
+	d.helper()
+	if n <= 0 {
+		d.tb.Fatalf("dsk: TickUntilSteady requires n > 0, got %d", n)
+		return
+	}
+	for range n {
+		d.Tick()
+		if err := d.engine.waitForQueuesIdle(d.tb.Context()); err != nil {
+			d.tb.Fatal(err)
+			return
+		}
+		if d.IsSteady() {
+			return
+		}
+	}
+	d.tb.Fatalf("controller did not reach steady state after %d ticks", n)
+}
+
+// IsSteady returns true when the event buffer is empty and all registered
+// queue wrappers have no pending or in-flight keys.
+//
+// Rate-limiter delay caveat: items requeued via AddRateLimited or AddAfter with
+// a non-zero duration are held in the rate-limiter's delay heap and are not
+// visible to queue.Len(). IsSteady may return a transient false positive until
+// those items clear the delay and enter the queue. Running the test inside a
+// testing/synctest bubble makes time virtual: calling synctest.Wait() advances
+// time past all pending delays, so AddRateLimited/AddAfter items surface
+// immediately and IsSteady reflects true quiescence.
+func (d *DSK) IsSteady() bool {
+	return d.engine.isSteady()
+}
+
+// InjectFault adds a fault to the DSK instance. Returns a handle for removal.
+func (d *DSK) InjectFault(f Fault) FaultHandle {
+	return d.faults.add(f)
+}
+
+// RemoveFault removes a previously injected fault.
+func (d *DSK) RemoveFault(h FaultHandle) {
+	d.faults.remove(h)
+}
+
+// ClearFaults removes all active faults.
+func (d *DSK) ClearFaults() {
+	d.faults.clear()
+}

--- a/dsk/dsk_fatal_test.go
+++ b/dsk/dsk_fatal_test.go
@@ -1,0 +1,116 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
+
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+// fakeTB implements dsk.TB for testing fatal-path behavior without stopping
+// the test goroutine. Fatalf/Fatal record messages instead of calling Goexit.
+type fakeTB struct {
+	ctx      context.Context
+	messages []string
+}
+
+func (f *fakeTB) Context() context.Context { return f.ctx }
+func (f *fakeTB) Fatal(args ...any)        { f.messages = append(f.messages, fmt.Sprint(args...)) }
+func (f *fakeTB) Fatalf(format string, args ...any) {
+	f.messages = append(f.messages, fmt.Sprintf(format, args...))
+}
+func (f *fakeTB) Errorf(format string, args ...any) {}
+func (f *fakeTB) Logf(format string, args ...any)   {}
+
+func (f *fakeTB) hasFatal() bool { return len(f.messages) > 0 }
+func (f *fakeTB) lastMessage() string {
+	if len(f.messages) == 0 {
+		return ""
+	}
+	return f.messages[len(f.messages)-1]
+}
+
+// nonReactableDynamic satisfies dynamic.Interface but not the dsk reactable interface.
+type nonReactableDynamic struct{ dynamic.Interface }
+
+// nonReactableTyped satisfies kubernetes.Interface but not the dsk reactable interface.
+type nonReactableTyped struct{ kubernetes.Interface }
+
+func TestDSK_Dynamic_UnsupportedClientCallsFatalf(t *testing.T) {
+	ftb := &fakeTB{ctx: t.Context()}
+	d := dsk.New(ftb)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Dynamic panicked instead of calling Fatalf: %v", r)
+			}
+		}()
+		d.Dynamic(&nonReactableDynamic{})
+	}()
+
+	if !ftb.hasFatal() {
+		t.Fatal("expected Fatalf to be called for unsupported dynamic client")
+	}
+}
+
+func TestDSK_Typed_UnsupportedClientCallsFatalf(t *testing.T) {
+	ftb := &fakeTB{ctx: t.Context()}
+	d := dsk.New(ftb)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Typed panicked instead of calling Fatalf: %v", r)
+			}
+		}()
+		d.Typed(&nonReactableTyped{})
+	}()
+
+	if !ftb.hasFatal() {
+		t.Fatal("expected Fatalf to be called for unsupported typed client")
+	}
+}
+
+func TestDSK_TickUntilSteady_FatalsOnZeroN(t *testing.T) {
+	ftb := &fakeTB{ctx: t.Context()}
+	d := dsk.New(ftb)
+
+	d.TickUntilSteady(0)
+
+	if !ftb.hasFatal() {
+		t.Fatal("expected Fatalf to be called for n=0")
+	}
+	if !strings.Contains(ftb.lastMessage(), "n > 0") {
+		t.Errorf("expected 'n > 0' in fatal message, got %q", ftb.lastMessage())
+	}
+}
+
+func TestDSK_TickUntilSteady_FatalsIfNeverSteady(t *testing.T) {
+	ftb := &fakeTB{ctx: t.Context()}
+	d := dsk.New(ftb)
+
+	underlying := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	defer underlying.ShutDown()
+	q := d.WrapQueue(underlying)
+
+	// Add an item that is never Get'd — queue stays non-idle every tick.
+	q.Add("stuck-key")
+
+	d.TickUntilSteady(2)
+
+	if !ftb.hasFatal() {
+		t.Fatal("expected Fatalf when controller never reaches steady state")
+	}
+	if !strings.Contains(ftb.lastMessage(), "steady state") {
+		t.Errorf("expected 'steady state' in fatal message, got %q", ftb.lastMessage())
+	}
+}

--- a/dsk/dsk_test.go
+++ b/dsk/dsk_test.go
@@ -1,0 +1,121 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/authzed/controller-idioms/client/fake"
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+var podsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+func TestDSK_TickDeliversFlushedEvents(t *testing.T) {
+	underlying := fake.NewClient(runtime.NewScheme())
+	d := dsk.New(t)
+
+	ctx := t.Context()
+
+	client := d.Dynamic(underlying)
+	w, err := client.Resource(podsGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	// Create through the DSK-wrapped client so preExpectWrite fires and
+	// Buffer() reliably waits for the event before returning.
+	_, err = client.Resource(podsGVR).Namespace("default").Create(ctx, testPod("pod1"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := d.Buffer()
+	if len(buf) == 0 {
+		t.Fatal("expected buffered event before Tick")
+	}
+
+	d.Tick()
+
+	select {
+	case ev := <-w.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("expected Added, got %v", ev.Type)
+		}
+	case <-t.Context().Done():
+		t.Fatal("expected event after Tick")
+	}
+
+	if len(d.Buffer()) != 0 {
+		t.Fatal("expected empty buffer after Tick")
+	}
+}
+
+func TestDSK_DeleteBuffersDeletedEvent(t *testing.T) {
+	underlying := fake.NewClient(runtime.NewScheme())
+	d := dsk.New(t)
+	client := d.Dynamic(underlying)
+	ctx := t.Context()
+
+	// Open watch before writes so all events are captured.
+	w, err := client.Resource(podsGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	// Create through the wrapped client (so preExpectWrite fires).
+	_, err = client.Resource(podsGVR).Namespace("default").Create(ctx, testPod("pod1"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Deliver the ADDED event.
+	d.Tick()
+	select {
+	case ev := <-w.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("expected Added, got %v", ev.Type)
+		}
+	case <-t.Context().Done():
+		t.Fatal("timeout waiting for Added event")
+	}
+
+	// Delete through the wrapped client — should buffer a DELETED event.
+	err = client.Resource(podsGVR).Namespace("default").Delete(ctx, "pod1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Buffer() must wait for the DELETED event to arrive before returning.
+	buf := d.Buffer()
+	if len(buf) != 1 {
+		t.Fatalf("expected 1 buffered DELETED event, got %d", len(buf))
+	}
+	if buf[0].Type != watch.Deleted {
+		t.Fatalf("expected Deleted, got %v", buf[0].Type)
+	}
+}
+
+func TestDSK_IsSteady(t *testing.T) {
+	d := dsk.New(t)
+	q := d.WrapQueue(workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()))
+	defer q.ShutDown()
+
+	if !d.IsSteady() {
+		t.Fatal("expected steady with empty queue and no buffered events")
+	}
+}
+
+func TestDSK_FlushEmptyIsNoop(t *testing.T) {
+	d := dsk.New(t)
+	// Neither nil nor an empty slice should panic, block, or return an error.
+	d.Flush(nil)
+	d.Flush([]dsk.PendingEvent{})
+}

--- a/dsk/dynamic_test.go
+++ b/dsk/dynamic_test.go
@@ -1,0 +1,50 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/authzed/controller-idioms/client/fake"
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+func TestDynamicWrapper_BuffersWatchEvents(t *testing.T) {
+	underlying := fake.NewClient(runtime.NewScheme())
+	d := dsk.New(t)
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	w, err := client.Resource(podsGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	_, err = client.Resource(podsGVR).Namespace("default").Create(ctx, testPod("pod1"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Event should be buffered, not immediately delivered.
+	select {
+	case <-w.ResultChan():
+		t.Fatal("expected event to be buffered, not delivered")
+	default:
+	}
+
+	d.Tick()
+
+	select {
+	case ev := <-w.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("expected Added event, got %v", ev.Type)
+		}
+	case <-t.Context().Done():
+		t.Fatal("expected event after Tick")
+	}
+}

--- a/dsk/engine.go
+++ b/dsk/engine.go
@@ -1,0 +1,611 @@
+//go:build dsk
+
+package dsk
+
+// Lock ordering (all code in this package must obey this to avoid deadlocks):
+//
+//	engine.mu → wrappedQueue.mu → workqueue.cond.L
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// eventSink receives a watch event during Flush. Implemented by ControlledWatch
+// (fake/channel path) and rawFrameSink (transport/HTTP path).
+type eventSink interface {
+	deliver(watch.Event)
+}
+
+// pendingEvent is an internal type pairing a watch event with its destination.
+// The dest field carries routing info for Flush; it is not exposed to callers.
+type pendingEvent struct {
+	event watch.Event
+	dest  eventSink
+	gvr   schema.GroupVersionResource
+	id    uint64 // unique ID assigned in addToBuffer; used for identity in removeFromBuffer
+}
+
+// gvrNSKey identifies a watch or handler registration by GVR and namespace.
+// ns == "" means the watch covers all namespaces (cluster-scoped or all-namespace).
+type gvrNSKey struct {
+	gvr schema.GroupVersionResource
+	ns  string
+}
+
+// watchEntry records one active watch drain goroutine along with its label selector.
+// sel is the label selector the API server uses to filter events for this watch.
+// A nil selector means match-all, which is correct for the fake client path where
+// the tracker sends all events to all watchers regardless of label selectors.
+type watchEntry struct {
+	gvrNSKey
+	sel labels.Selector
+}
+
+// handlerEntry records one AddEventHandler registration on an informer.
+// sel is the informer's label selector; nil means match-all.
+// For fake clients, sel is always nil because the fake tracker sends all events
+// to all watchers regardless of label selectors, so all handlers are always called.
+type handlerEntry struct {
+	gvrNSKey
+	sel labels.Selector
+}
+
+// engine is the shared tick coordination state between client wrappers and queue wrappers.
+// All fields are guarded by mu. pendingCond is broadcast whenever pendingRVs or
+// pendingAnyEvent transitions to empty so waitForPendingRVs wakes promptly.
+type engine struct {
+	tb               TB // optional; used for diagnostic logging only
+	mu               sync.Mutex
+	pendingCond      *sync.Cond
+	buffer           []pendingEvent
+	queues           []tickableQueue
+	watchEntries     []watchEntry                        // active drain goroutines with their label selectors
+	pendingRVs       map[string]int                      // RV → remaining event arrivals expected
+	pendingAnyEvent  map[schema.GroupVersionResource]int // GVR → events expected (RV-agnostic)
+	inFlightHandlers int64                               // accessed atomically; counts in-progress AddEventHandler callbacks
+	handlerEntries   []handlerEntry                      // AddEventHandler registrations with their label selectors
+	pendingCalls     int64                               // accessed atomically; credited per expected handler call, debited on completion
+	nextEventID      uint64                              // accessed atomically; monotonically increasing IDs for buffered events
+}
+
+func newEngine() *engine {
+	e := &engine{
+		pendingRVs:      make(map[string]int),
+		pendingAnyEvent: make(map[schema.GroupVersionResource]int),
+	}
+	e.pendingCond = sync.NewCond(&e.mu)
+	return e
+}
+
+// selectorString returns a canonical string for a label selector for use in
+// equality comparisons. Nil and labels.Everything() both return "" (match-all).
+// labels.Nothing() returns "<nothing>" to avoid colliding with the match-all case.
+// Requirements are sorted so that logically equivalent selectors with different
+// requirement orderings produce the same string.
+func selectorString(sel labels.Selector) string {
+	if sel == nil {
+		return ""
+	}
+	reqs, selectable := sel.Requirements()
+	if !selectable {
+		return "<nothing>"
+	}
+	strs := make([]string, len(reqs))
+	for i := range reqs {
+		strs[i] = reqs[i].String()
+	}
+	sort.Strings(strs)
+	return strings.Join(strs, ",")
+}
+
+// handlerStart records that an AddEventHandler callback has begun executing.
+// Must be paired with a handlerDone call.
+func (e *engine) handlerStart() {
+	atomic.AddInt64(&e.inFlightHandlers, 1)
+}
+
+// handlerDone records that an AddEventHandler callback has finished. When the
+// count reaches zero it broadcasts on pendingCond so waitForHandlersIdle wakes.
+// Acquires e.mu briefly to avoid a lost-wakeup race with waitForHandlersIdle.
+func (e *engine) handlerDone() {
+	if atomic.AddInt64(&e.inFlightHandlers, -1) == 0 {
+		e.mu.Lock()
+		e.pendingCond.Broadcast()
+		e.mu.Unlock()
+	}
+}
+
+// handlerDoneCall decrements pendingCalls by one when an AddEventHandler
+// callback completes. It is a saturating decrement: if pendingCalls is already
+// zero (e.g. for initial-list callbacks that fired before any tick), it is a
+// no-op. Broadcasts on pendingCond when the count reaches zero so that
+// waitForHandlersIdle can detect completion.
+func (e *engine) handlerDoneCall() {
+	for {
+		old := atomic.LoadInt64(&e.pendingCalls)
+		if old <= 0 {
+			return // no outstanding credits — initial-list or spurious call
+		}
+		if atomic.CompareAndSwapInt64(&e.pendingCalls, old, old-1) {
+			if old == 1 {
+				e.mu.Lock()
+				e.pendingCond.Broadcast()
+				e.mu.Unlock()
+			}
+			return
+		}
+	}
+}
+
+// registerHandler records that an AddEventHandler call has been made on an
+// informer watching (gvr, ns) with the given label selector. sel nil means
+// match-all (used for fake clients where the tracker does not filter events).
+// This count is used by flush() to credit pendingCalls before delivering events,
+// so waitForHandlersIdle can block until all handler invocations triggered by
+// those events have completed.
+func (e *engine) registerHandler(gvr schema.GroupVersionResource, ns string, sel labels.Selector) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.handlerEntries = append(e.handlerEntries, handlerEntry{
+		gvrNSKey: gvrNSKey{gvr: gvr, ns: ns},
+		sel:      sel,
+	})
+}
+
+// unregisterHandler removes the first handler entry matching (gvr, ns, sel).
+// Called by dskSharedIndexInformer.RemoveEventHandler to keep handlerEntries
+// in sync with the underlying informer's listener list. Callers must pass the
+// same sel value that was passed to registerHandler.
+func (e *engine) unregisterHandler(gvr schema.GroupVersionResource, ns string, sel labels.Selector) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	selStr := selectorString(sel)
+	for i, he := range e.handlerEntries {
+		if he.gvr == gvr && he.ns == ns && selectorString(he.sel) == selStr {
+			e.handlerEntries = append(e.handlerEntries[:i], e.handlerEntries[i+1:]...)
+			return
+		}
+	}
+	if e.tb != nil {
+		e.tb.Logf("dsk: unregisterHandler: no matching entry for gvr=%v ns=%s sel=%s — selector mismatch between registerHandler and unregisterHandler can cause Tick/Flush to hang", gvr, ns, selectorString(sel))
+	}
+}
+
+// wakeOnCancel starts a goroutine that broadcasts on pendingCond when ctx is
+// cancelled, so that callers blocked in pendingCond.Wait() can re-check
+// ctx.Err() and return. The returned stop function must be called (typically
+// via defer) to clean up the goroutine when the wait completes normally.
+//
+// Broadcasting without holding e.mu is safe: the waiter re-checks ctx.Err()
+// immediately after waking, so a missed broadcast only causes one extra loop
+// iteration rather than a lost cancellation.
+func (e *engine) wakeOnCancel(ctx context.Context) (stop func()) {
+	if ctx.Err() != nil {
+		e.pendingCond.Broadcast()
+		return func() {}
+	}
+	ch := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			e.pendingCond.Broadcast()
+		case <-ch:
+		}
+	}()
+	return func() { close(ch) }
+}
+
+// waitForHandlersIdle blocks until all in-flight AddEventHandler callbacks have
+// returned AND all expected handler calls (credited via pendingCalls) have
+// completed, or ctx is cancelled. Called by flush() after delivering events and
+// before closing the tick window.
+func (e *engine) waitForHandlersIdle(ctx context.Context) error {
+	defer e.wakeOnCancel(ctx)()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for atomic.LoadInt64(&e.inFlightHandlers) > 0 || atomic.LoadInt64(&e.pendingCalls) > 0 {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		e.pendingCond.Wait()
+	}
+	return ctx.Err()
+}
+
+// registerWatch records that a drain goroutine has started for the given GVR,
+// namespace, and label selector. ns == "" means the watch covers all namespaces.
+// sel nil means match-all (correct for the fake client path; also used when no
+// labelSelector query parameter was present on the watch request).
+func (e *engine) registerWatch(gvr schema.GroupVersionResource, ns string, sel labels.Selector) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.watchEntries = append(e.watchEntries, watchEntry{
+		gvrNSKey: gvrNSKey{gvr: gvr, ns: ns},
+		sel:      sel,
+	})
+}
+
+// unregisterWatch records that a drain goroutine has exited for the given GVR,
+// namespace, and label selector. Removes the first matching entry; the caller
+// must pass the same sel value that was passed to registerWatch.
+func (e *engine) unregisterWatch(gvr schema.GroupVersionResource, ns string, sel labels.Selector) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	selStr := selectorString(sel)
+	for i, we := range e.watchEntries {
+		if we.gvr == gvr && we.ns == ns && selectorString(we.sel) == selStr {
+			e.watchEntries = append(e.watchEntries[:i], e.watchEntries[i+1:]...)
+			return
+		}
+	}
+}
+
+// preExpectWrite atomically increments pendingAnyEvent[gvr] by the number of
+// active watches that will receive an event for an object write in objectNS,
+// BEFORE the write operation, so that addToBuffer cannot decrement before
+// expectRV/upgradeExpect runs. Returns the watch count N that was observed
+// (0 if no watches or non-write verb). Callers must pass this N to
+// upgradeExpect or cancelPreExpect so those functions remove exactly the count
+// that was added, even if watchEntries changes in the interim.
+//
+// objectLabels is the label set of the object being written. It is used to
+// filter watches whose label selector does not match the object, so that DSK
+// does not wait for events that the API server will never send. A nil
+// objectLabels disables label filtering (used for patch and delete, where the
+// final labels are not known at pre-expect time — this may over-count for real
+// clusters with selector-filtered watches, but is correct for the common cases).
+//
+// An all-namespace watcher (ns=="") receives events for every object namespace.
+// A namespace-specific watcher (ns=="foo") receives events only for that namespace.
+func (e *engine) preExpectWrite(verb string, gvr schema.GroupVersionResource, objectNS string, objectLabels map[string]string) int {
+	switch verb {
+	case "create", "update", "patch", "delete":
+	default:
+		return 0
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	filterByLabels := objectLabels != nil
+	var ls labels.Set
+	if filterByLabels {
+		ls = labels.Set(objectLabels)
+	}
+
+	n := 0
+	for _, we := range e.watchEntries {
+		if we.gvr != gvr {
+			continue
+		}
+		// Namespace matching: all-namespace watcher ("") matches all objects;
+		// namespace-specific watcher matches only that namespace.
+		if we.ns != "" && we.ns != objectNS {
+			continue
+		}
+		// Selector matching: nil selector (match-all) always counts.
+		// Non-nil selector is only checked when objectLabels is known; when
+		// unknown (patch/delete), we conservatively count the watch.
+		if filterByLabels && we.sel != nil && !we.sel.Matches(ls) {
+			continue
+		}
+		n++
+	}
+	if n > 0 {
+		e.pendingAnyEvent[gvr] += n
+	}
+	return n
+}
+
+// upgradeExpect converts a pre-expected RV-agnostic count to RV-based tracking.
+// Call after a successful write when the returned object has a non-empty RV.
+// n must be the value returned by the corresponding preExpectWrite call so that
+// exactly the count that was pre-incremented is removed, regardless of any
+// concurrent watch goroutine exits that may have changed watchCounts[gvr].
+func (e *engine) upgradeExpect(gvr schema.GroupVersionResource, rv string, n int) {
+	if n <= 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Remove exactly n from pendingAnyEvent (the count that was pre-incremented).
+	if cur := e.pendingAnyEvent[gvr]; cur <= n {
+		delete(e.pendingAnyEvent, gvr)
+	} else {
+		e.pendingAnyEvent[gvr] = cur - n
+	}
+	// Add to RV-based tracking.
+	e.pendingRVs[rv] = n
+}
+
+// cancelPreExpect removes a pre-increment added by preExpectWrite when the
+// write failed or was not handled by the reactor. n must be the value returned
+// by the corresponding preExpectWrite call so that exactly the count that was
+// pre-incremented is removed, regardless of any concurrent watch goroutine
+// exits that may have changed watchCounts[gvr].
+func (e *engine) cancelPreExpect(gvr schema.GroupVersionResource, n int) {
+	if n <= 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if cur := e.pendingAnyEvent[gvr]; cur <= n {
+		delete(e.pendingAnyEvent, gvr)
+	} else {
+		e.pendingAnyEvent[gvr] = cur - n
+	}
+	// Broadcast in case we decremented to 0.
+	if len(e.pendingRVs)+len(e.pendingAnyEvent) == 0 {
+		e.pendingCond.Broadcast()
+	}
+}
+
+func (e *engine) addToBuffer(pe pendingEvent) {
+	pe.id = atomic.AddUint64(&e.nextEventID, 1)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.buffer = append(e.buffer, pe)
+	// Decrement the arrival count for this RV; remove when all copies have arrived.
+	if obj, ok := pe.event.Object.(interface{ GetResourceVersion() string }); ok {
+		rv := obj.GetResourceVersion()
+		if n := e.pendingRVs[rv]; n <= 1 {
+			delete(e.pendingRVs, rv)
+		} else {
+			e.pendingRVs[rv] = n - 1
+		}
+	}
+	// Decrement the RV-agnostic counter (used when the underlying store does not
+	// assign ResourceVersions, e.g. the plain fake object tracker).
+	// Note: for writes where upgradeExpect already ran successfully, upgradeExpect
+	// will have already zeroed pendingAnyEvent[gvr] and moved the count to
+	// pendingRVs. In that case the n > 0 guard below is a no-op for this event;
+	// only events from writes with an empty RV (or tracker-fallback writes) will
+	// actually decrement pendingAnyEvent here.
+	if pe.gvr != (schema.GroupVersionResource{}) {
+		if n := e.pendingAnyEvent[pe.gvr]; n > 0 {
+			if n <= 1 {
+				delete(e.pendingAnyEvent, pe.gvr)
+			} else {
+				e.pendingAnyEvent[pe.gvr] = n - 1
+			}
+		}
+	}
+	// Notify waitForPendingRVs in case all pending counts are now zero.
+	if len(e.pendingRVs)+len(e.pendingAnyEvent) == 0 {
+		e.pendingCond.Broadcast()
+	}
+}
+
+// waitForBufferCount blocks until at least n events are in the buffer, or ctx
+// is cancelled. sync.Cond.Wait is durably blocking for testing/synctest, so
+// this is safe to call from within a synctest bubble.
+func (e *engine) waitForBufferCount(ctx context.Context, n int) error {
+	defer e.wakeOnCancel(ctx)()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for len(e.buffer) < n {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		e.pendingCond.Wait()
+	}
+	return ctx.Err()
+}
+
+// waitForPendingRVs blocks until all tracked RVs and RV-agnostic event counts
+// have arrived in the buffer, or ctx is cancelled.
+func (e *engine) waitForPendingRVs(ctx context.Context) error {
+	defer e.wakeOnCancel(ctx)()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for len(e.pendingRVs)+len(e.pendingAnyEvent) > 0 {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		e.pendingCond.Wait()
+	}
+	return ctx.Err()
+}
+
+// snapshot returns a copy of the current buffer contents.
+func (e *engine) snapshot() []pendingEvent {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]pendingEvent, len(e.buffer))
+	copy(out, e.buffer)
+	return out
+}
+
+// removeFromBuffer removes the given events from the buffer by identity.
+// Identity is defined as (dest pointer, event.Type, event.Object pointer).
+// Two pendingEvents are identical if and only if they originated from the same
+// addToBuffer call — callers should pass values taken from snapshot() rather
+// than constructing new pendingEvent values.
+//
+// Each entry in flushed consumes exactly one matching buffer entry. This
+// prevents over-removal when two buffer entries are structurally equal (same
+// dest and same event value) — for example, if the same watch connection
+// receives the same event twice — and only one copy was flushed.
+func (e *engine) removeFromBuffer(flushed []pendingEvent) {
+	if len(flushed) == 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Build an id→count map so the outer loop is O(n) rather than O(n×m).
+	// Counts handle the rare case where the same event ID appears multiple times.
+	remove := make(map[uint64]int, len(flushed))
+	for _, f := range flushed {
+		remove[f.id]++
+	}
+	remaining := e.buffer[:0:0] // fresh backing array; prevents aliasing
+	for _, be := range e.buffer {
+		if remove[be.id] > 0 {
+			remove[be.id]--
+		} else {
+			remaining = append(remaining, be)
+		}
+	}
+	e.buffer = remaining
+}
+
+func (e *engine) registerQueue(q tickableQueue) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.queues = append(e.queues, q)
+}
+
+// hasQueues reports whether any queue wrappers have been registered via WrapQueue
+// or WrapTypedQueue. Called by DSK.flush to warn when events are flushed without
+// any queue tracking in place.
+func (e *engine) hasQueues() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.queues) > 0
+}
+
+// flush delivers the given events to their watch channels, then waits for
+// all registered queue wrappers to report tick completion.
+//
+// Before delivering, flush credits pendingCalls for each event based on the
+// number of AddEventHandler registrations for that event's (GVR, namespace).
+// This ensures waitForHandlersIdle blocks until all informer callbacks
+// triggered by the delivered events have completed, even if the reflector
+// goroutine hasn't started processing the event yet when waitForHandlersIdle
+// is first called.
+func (e *engine) flush(ctx context.Context, events []pendingEvent) error {
+	e.mu.Lock()
+	queues := make([]tickableQueue, len(e.queues))
+	copy(queues, e.queues)
+
+	// Credit pendingCalls before delivering so waitForHandlersIdle has a
+	// non-zero count to block on even if the reflector hasn't consumed the
+	// event from the watch channel yet.
+	//
+	// For each event, count only the handlers whose (GVR, namespace, selector)
+	// matches the event's object. The event object always carries its current
+	// labels, so we can filter precisely. This avoids over-crediting when
+	// real-cluster informers have label selectors that exclude the event's object.
+	type labelsGetter interface {
+		GetNamespace() string
+		GetLabels() map[string]string
+	}
+	for _, pe := range events {
+		var objectNS string
+		var ls labels.Set
+		if meta, ok := pe.event.Object.(labelsGetter); ok {
+			objectNS = meta.GetNamespace()
+			ls = labels.Set(meta.GetLabels()) // nil map is valid as an empty Set
+		}
+		n := 0
+		for _, he := range e.handlerEntries {
+			if he.gvr != pe.gvr {
+				continue
+			}
+			if he.ns != "" && he.ns != objectNS {
+				continue
+			}
+			if he.sel != nil && !he.sel.Matches(ls) {
+				continue
+			}
+			n++
+		}
+		if n > 0 {
+			atomic.AddInt64(&e.pendingCalls, int64(n))
+		}
+	}
+	e.mu.Unlock()
+
+	for _, q := range queues {
+		q.beginTick()
+	}
+
+	// Deliver events in a background goroutine so that Tick/Flush can wait for
+	// handler completion without the caller needing to run a concurrent consumer.
+	// The channel is unbuffered: deliver blocks until the consumer (informer
+	// reflector) reads. Running delivery off-thread lets Tick return before the
+	// consumer has drained all events — this matches DSK's expected usage pattern
+	// where the test calls Tick and then reads from ResultChan.
+	// Events within a single flush are delivered in order.
+	if len(events) > 0 {
+		go func() {
+			for _, pe := range events {
+				pe.dest.deliver(pe.event)
+			}
+		}()
+	}
+
+	// Wait for all AddEventHandler callbacks to return (both in-flight and
+	// those yet to start, tracked via pendingCalls) before closing the tick
+	// window. This ensures every queue.Add() triggered by delivered events has
+	// been made before we check for completion.
+	if err := e.waitForHandlersIdle(ctx); err != nil {
+		return err
+	}
+
+	// Close the Add() window on all queue wrappers.
+	for _, q := range queues {
+		q.closeWindow()
+	}
+
+	// Wait for all queues to finish their tick.
+	for _, q := range queues {
+		select {
+		case <-q.doneCh():
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// waitForQueuesIdle waits until all registered queue wrappers report idle
+// (Len()==0 and inFlight=={}), or ctx is cancelled. It skips queues that had
+// no activity during the last tick (active==false) to avoid hanging when items
+// pre-existed in the queue before the tick and were never Get'd.
+//
+// Called by TickUntilSteady after each Tick() and before IsSteady() so that
+// items requeued within a tick (via Add by handlers or via AddAfter/Done dirty
+// path) are drained before the steady-state check. Not called from flush()
+// directly, which allows tests that drain the queue manually after Tick() to
+// proceed without blocking.
+func (e *engine) waitForQueuesIdle(ctx context.Context) error {
+	e.mu.Lock()
+	queues := make([]tickableQueue, len(e.queues))
+	copy(queues, e.queues)
+	e.mu.Unlock()
+	for _, q := range queues {
+		if err := q.waitForIdle(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isSteady acquires engine.mu then calls q.isIdle() per the lock ordering above.
+//
+// Note: Tick/Flush only waits for in-flight items (Get→Done) to complete, not
+// for Len() to reach zero. IsSteady() is the authoritative check for full
+// quiescence — it verifies both the buffer is empty AND all queues are idle
+// (no in-flight items AND Len() == 0).
+func (e *engine) isSteady() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if len(e.buffer) > 0 {
+		return false
+	}
+	for _, q := range e.queues {
+		if !q.isIdle() {
+			return false
+		}
+	}
+	return true
+}

--- a/dsk/engine_test.go
+++ b/dsk/engine_test.go
@@ -1,0 +1,394 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+// loggingTB is a minimal TB implementation that captures Logf calls.
+type loggingTB struct {
+	logs []string
+}
+
+func (l *loggingTB) Context() context.Context          { return context.Background() }
+func (l *loggingTB) Fatal(args ...any)                 {}
+func (l *loggingTB) Fatalf(format string, args ...any) {}
+func (l *loggingTB) Errorf(format string, args ...any) {}
+func (l *loggingTB) Logf(format string, args ...any) {
+	l.logs = append(l.logs, fmt.Sprintf(format, args...))
+}
+
+func TestDskSharedIndexInformer_RemoveEventHandler_UnregistersHandler(t *testing.T) {
+	eng := ExportNewEngine()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	si := cache.NewSharedIndexInformer(&cache.ListWatch{}, &unstructured.Unstructured{}, 0, cache.Indexers{})
+	wrapped := ExportNewDskSharedIndexInformer(si, eng, gvr, "default", nil)
+
+	reg, err := wrapped.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := ExportHandlerEntryCount(eng); count != 1 {
+		t.Fatalf("expected 1 handler entry after AddEventHandler, got %d", count)
+	}
+
+	if err := wrapped.RemoveEventHandler(reg); err != nil {
+		t.Fatal(err)
+	}
+	if count := ExportHandlerEntryCount(eng); count != 0 {
+		t.Fatalf("expected 0 handler entries after RemoveEventHandler, got %d", count)
+	}
+}
+
+func TestDskSharedIndexInformer_AddEventHandlerWithOptions_RegistersHandler(t *testing.T) {
+	eng := ExportNewEngine()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	si := cache.NewSharedIndexInformer(&cache.ListWatch{}, &unstructured.Unstructured{}, 0, cache.Indexers{})
+	wrapped := ExportNewDskSharedIndexInformer(si, eng, gvr, "default", nil)
+
+	_, err := wrapped.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{}, cache.HandlerOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count := ExportHandlerEntryCount(eng); count != 1 {
+		t.Fatalf("expected 1 handler entry after AddEventHandlerWithOptions, got %d", count)
+	}
+}
+
+func TestEngine_BufferAndSnapshot(t *testing.T) {
+	e := newEngine()
+	cw := NewControlledWatch(t)
+
+	ev := watch.Event{Type: watch.Added}
+	e.addToBuffer(pendingEvent{event: ev, dest: cw})
+
+	buf := e.snapshot()
+	if len(buf) != 1 {
+		t.Fatalf("expected 1 buffered event, got %d", len(buf))
+	}
+	if buf[0].event.Type != watch.Added {
+		t.Fatalf("unexpected event type: %v", buf[0].event.Type)
+	}
+}
+
+func TestEngine_RemoveFromBuffer(t *testing.T) {
+	e := newEngine()
+	cw := NewControlledWatch(t)
+
+	ev1 := watch.Event{Type: watch.Added}
+	ev2 := watch.Event{Type: watch.Modified}
+	e.addToBuffer(pendingEvent{event: ev1, dest: cw})
+	e.addToBuffer(pendingEvent{event: ev2, dest: cw})
+
+	// Remove only ev1: use snapshot to obtain the ID-bearing pendingEvent.
+	snap := e.snapshot()
+	e.removeFromBuffer([]pendingEvent{snap[0]})
+
+	buf := e.snapshot()
+	if len(buf) != 1 {
+		t.Fatalf("expected 1 buffered event after removal, got %d", len(buf))
+	}
+	if buf[0].event.Type != watch.Modified {
+		t.Fatalf("unexpected remaining event type: %v", buf[0].event.Type)
+	}
+}
+
+func TestEngine_SnapshotIsIsolated(t *testing.T) {
+	e := newEngine()
+	cw := NewControlledWatch(t)
+
+	ev := watch.Event{Type: watch.Added}
+	e.addToBuffer(pendingEvent{event: ev, dest: cw})
+
+	snap := e.snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("expected 1 event in snapshot, got %d", len(snap))
+	}
+
+	// Adding more events should not affect the snapshot
+	e.addToBuffer(pendingEvent{event: watch.Event{Type: watch.Modified}, dest: cw})
+
+	if len(snap) != 1 {
+		t.Fatal("snapshot was mutated when buffer was modified")
+	}
+}
+
+func TestEngine_HandlerTracking_IdleByDefault(t *testing.T) {
+	e := ExportNewEngine()
+	ctx := t.Context()
+	if err := e.WaitForHandlersIdle(ctx); err != nil {
+		t.Fatalf("expected handlers idle immediately: %v", err)
+	}
+}
+
+func TestEngine_HandlerTracking_BlocksWhileInFlight(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		e := ExportNewEngine()
+		e.HandlerStart()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() { done <- e.WaitForHandlersIdle(ctx) }()
+
+		synctest.Wait() // goroutine settled in sync.Cond.Wait
+		select {
+		case err := <-done:
+			t.Fatalf("expected WaitForHandlersIdle to block, got %v", err)
+		default:
+		}
+
+		e.HandlerDone()
+		synctest.Wait()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("expected nil after HandlerDone, got %v", err)
+			}
+		default:
+			t.Fatal("expected WaitForHandlersIdle to unblock after HandlerDone")
+		}
+	})
+}
+
+func TestEngine_HandlerTracking_CancelContext(t *testing.T) {
+	e := ExportNewEngine()
+
+	e.HandlerStart()
+	defer e.HandlerDone()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- e.WaitForHandlersIdle(ctx) }()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected context error, got nil")
+		}
+	case <-t.Context().Done():
+		t.Fatal("expected WaitForHandlersIdle to return on cancel")
+	}
+}
+
+func TestEngine_TrackedHandler_CountsCallbacks(t *testing.T) {
+	e := ExportNewEngine()
+
+	callCount := 0
+	inner := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { callCount++ },
+	}
+	wrapped := ExportTrackedHandler(inner, e)
+
+	if atomic.LoadInt64(ExportInFlightHandlers(e)) != 0 {
+		t.Fatal("expected 0 in-flight before any callback")
+	}
+
+	// Simulate synchronous invocation (as listener.run would do it).
+	wrapped.OnAdd("obj", false)
+
+	if callCount != 1 {
+		t.Fatalf("expected inner handler called once, got %d", callCount)
+	}
+	if atomic.LoadInt64(ExportInFlightHandlers(e)) != 0 {
+		t.Fatal("expected 0 in-flight after callback returns")
+	}
+}
+
+func TestEngine_PendingCalls_BlocksWaitForHandlersIdle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		e := ExportNewEngine()
+		gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+		e.RegisterHandler(gvr, "default", nil)
+		e.HandlerDoneCall() // no-op; pendingCalls still 0
+		atomic.AddInt64(ExportPendingCalls(e), 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() { done <- e.WaitForHandlersIdle(ctx) }()
+
+		synctest.Wait() // goroutine settled in sync.Cond.Wait
+		select {
+		case err := <-done:
+			t.Fatalf("expected WaitForHandlersIdle to block, got %v", err)
+		default:
+		}
+
+		e.HandlerDoneCall()
+		synctest.Wait()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("expected nil after HandlerDoneCall, got %v", err)
+			}
+		default:
+			t.Fatal("expected WaitForHandlersIdle to unblock after HandlerDoneCall")
+		}
+	})
+}
+
+func TestEngine_PendingCalls_SaturatingDecrement(t *testing.T) {
+	// HandlerDoneCall with pendingCalls=0 should be a safe no-op, not go negative.
+	e := ExportNewEngine()
+
+	e.HandlerDoneCall() // pendingCalls=0 → no-op
+	e.HandlerDoneCall()
+
+	if v := atomic.LoadInt64(ExportPendingCalls(e)); v != 0 {
+		t.Fatalf("expected pendingCalls=0, got %d", v)
+	}
+}
+
+// TestEngine_PreExpectWrite_SelectorFiltering verifies that preExpectWrite only
+// counts watches whose label selector matches the object's labels.
+func TestEngine_PreExpectWrite_SelectorFiltering(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	selFoo, _ := labels.Parse("app=foo")
+	selBar, _ := labels.Parse("app=bar")
+
+	tests := []struct {
+		name         string
+		watchSel     labels.Selector
+		objectLabels map[string]string
+		expectCount  int
+	}{
+		{
+			name:         "nil selector matches all labels",
+			watchSel:     nil,
+			objectLabels: map[string]string{"app": "foo"},
+			expectCount:  1,
+		},
+		{
+			name:         "matching selector counts the watch",
+			watchSel:     selFoo,
+			objectLabels: map[string]string{"app": "foo"},
+			expectCount:  1,
+		},
+		{
+			name:         "non-matching selector skips the watch",
+			watchSel:     selBar,
+			objectLabels: map[string]string{"app": "foo"},
+			expectCount:  0,
+		},
+		{
+			name:         "nil object labels disables filtering (conservative)",
+			watchSel:     selFoo,
+			objectLabels: nil,
+			expectCount:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEngine()
+			e.registerWatch(gvr, "default", tt.watchSel)
+			n := e.preExpectWrite("create", gvr, "default", tt.objectLabels)
+			if n != tt.expectCount {
+				t.Fatalf("preExpectWrite: got %d, want %d", n, tt.expectCount)
+			}
+		})
+	}
+}
+
+// TestEngine_Flush_SelectorFiltering verifies that flush() only credits
+// pendingCalls for handlers whose label selector matches the event's object.
+// If no handlers match, flush() must not block waiting for handler completion.
+func TestEngine_Flush_SelectorFiltering(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	selFoo, _ := labels.Parse("app=foo")
+
+	makeEvent := func(labelVal string) pendingEvent {
+		cw := NewControlledWatch(t)
+		// Drain in background so Deliver doesn't block (unbuffered channel).
+		go func() {
+			for range cw.ResultChan() {
+			}
+		}()
+		t.Cleanup(func() { cw.Stop() })
+		obj := &unstructured.Unstructured{}
+		obj.SetNamespace("default")
+		obj.SetLabels(map[string]string{"app": labelVal})
+		return pendingEvent{
+			event: watch.Event{Type: watch.Added, Object: obj},
+			dest:  cw,
+			gvr:   gvr,
+		}
+	}
+
+	t.Run("non-matching selector does not credit pendingCalls", func(t *testing.T) {
+		e := newEngine()
+		// Handler watches for app=foo, but event is for app=bar.
+		e.registerHandler(gvr, "default", selFoo)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+		defer cancel()
+
+		// flush must return immediately — no pendingCalls credited.
+		if err := e.flush(ctx, []pendingEvent{makeEvent("bar")}); err != nil {
+			t.Fatalf("flush: unexpected error (likely hung waiting for pendingCalls): %v", err)
+		}
+		if v := atomic.LoadInt64(ExportPendingCalls(e)); v != 0 {
+			t.Fatalf("expected pendingCalls=0 after flush with non-matching selector, got %d", v)
+		}
+	})
+
+	t.Run("matching selector credits and debits pendingCalls", func(t *testing.T) {
+		e := newEngine()
+		// Handler watches for app=foo, event is also for app=foo.
+		e.registerHandler(gvr, "default", selFoo)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+		defer cancel()
+
+		// flush credits pendingCalls=1 before deliver; deliver to ControlledWatch
+		// does NOT call OnAdd (no reflector running), so pendingCalls stays at 1.
+		// We verify the credit happened and then manually debit to confirm mechanics.
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			e.handlerDoneCall() // simulate handler completing
+		}()
+
+		if err := e.flush(ctx, []pendingEvent{makeEvent("foo")}); err != nil {
+			t.Fatalf("flush: unexpected error: %v", err)
+		}
+	})
+}
+
+func TestEngine_UnregisterHandler_LogsWarningOnMiss(t *testing.T) {
+	e := newEngine()
+	ltb := &loggingTB{}
+	e.tb = ltb
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	// Unregister with no prior registration — should log a warning.
+	e.unregisterHandler(gvr, "default", nil)
+	if len(ltb.logs) == 0 {
+		t.Fatal("expected warning log when unregisterHandler finds no matching entry")
+	}
+	if !strings.Contains(ltb.logs[0], "unregisterHandler") {
+		t.Errorf("expected log to mention unregisterHandler, got %q", ltb.logs[0])
+	}
+}

--- a/dsk/export_test.go
+++ b/dsk/export_test.go
@@ -1,0 +1,51 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ExportNewEngine creates a new engine for testing. Not for production use.
+func ExportNewEngine() *engine { return newEngine() }
+
+// Snapshot returns a copy of the current event buffer. For testing.
+func (e *engine) Snapshot() []pendingEvent { return e.snapshot() }
+
+// FlushAll delivers all buffered events and waits for completion. For testing.
+func (e *engine) FlushAll(ctx context.Context) error {
+	return e.flush(ctx, e.snapshot())
+}
+
+func (e *engine) HandlerStart()                                 { e.handlerStart() }
+func (e *engine) HandlerDone()                                  { e.handlerDone() }
+func (e *engine) HandlerDoneCall()                              { e.handlerDoneCall() }
+func (e *engine) WaitForHandlersIdle(ctx context.Context) error { return e.waitForHandlersIdle(ctx) }
+func (e *engine) RegisterHandler(gvr schema.GroupVersionResource, ns string, sel labels.Selector) {
+	e.registerHandler(gvr, ns, sel)
+}
+
+func ExportTrackedHandler(h cache.ResourceEventHandler, e *engine) cache.ResourceEventHandler {
+	return &trackedHandler{inner: h, eng: e}
+}
+func ExportInFlightHandlers(e *engine) *int64 { return &e.inFlightHandlers }
+func ExportPendingCalls(e *engine) *int64     { return &e.pendingCalls }
+
+var (
+	GVRFromPath        = gvrFromPath
+	ObjectNameFromPath = objectNameFromPath
+)
+
+func ExportHandlerEntryCount(e *engine) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.handlerEntries)
+}
+
+func ExportNewDskSharedIndexInformer(si cache.SharedIndexInformer, e *engine, gvr schema.GroupVersionResource, ns string, sel labels.Selector) cache.SharedIndexInformer {
+	return &dskSharedIndexInformer{SharedIndexInformer: si, eng: e, gvr: gvr, namespace: ns, selector: sel}
+}

--- a/dsk/fault.go
+++ b/dsk/fault.go
@@ -1,0 +1,206 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// HoldFault returns a FaultBuilder that blocks matching calls until the
+// returned release function is called. This is the deterministic alternative
+// to DelayFault for DSK tests: because a fault executes on the controller's
+// reconcile goroutine, a time.After delay would prevent the current tick from
+// completing (the engine waits for all reconciles via doneCh). HoldFault lets
+// the test explicitly control when the blocked call unblocks.
+//
+// Context cancellation unblocks the hold in the transport path (where the
+// per-request context is used). In the reactor (fake client) path, client-go
+// does not expose the per-request context through the reactor chain, so only
+// DSK-level context cancellation (test end) will unblock a held reactor call.
+//
+//	hold, release := dsk.HoldFault()
+//	d.InjectFault(hold.OnVerb("patch"))
+//	// ... trigger the operation ...
+//	release() // unblock the blocked API call
+func HoldFault() (FaultBuilder, func()) {
+	ch := make(chan struct{})
+	var once sync.Once
+	release := func() { once.Do(func() { close(ch) }) }
+	f := &baseFault{
+		effectFn: func(ctx context.Context) error {
+			select {
+			case <-ch:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+	return f, release
+}
+
+// Fault is a single injectable error condition.
+type Fault interface {
+	matches(verb string, gvr schema.GroupVersionResource, namespace, name string) bool
+	execute(ctx context.Context) error
+}
+
+// FaultHandle is returned by InjectFault; pass to RemoveFault to remove the fault.
+type FaultHandle int
+
+// faultEntry pairs a fault with its insertion handle for removal.
+type faultEntry struct {
+	h FaultHandle
+	f Fault
+}
+
+// faultSet holds the active faults in insertion order. Methods are safe for
+// concurrent use. apply() iterates in reverse (LIFO): the last-injected fault
+// fires first when multiple faults match the same call.
+type faultSet struct {
+	mu     sync.RWMutex
+	faults []faultEntry
+	next   FaultHandle
+}
+
+func newFaultSet() *faultSet {
+	return &faultSet{next: 1} // 0 is reserved; a zero FaultHandle is never valid
+}
+
+func (fs *faultSet) add(f Fault) FaultHandle {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	h := fs.next
+	fs.next++
+	fs.faults = append(fs.faults, faultEntry{h: h, f: f})
+	return h
+}
+
+func (fs *faultSet) remove(h FaultHandle) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	out := fs.faults[:0:0] // defensive: fresh backing array prevents aliasing with old slice
+	for _, e := range fs.faults {
+		if e.h != h {
+			out = append(out, e)
+		}
+	}
+	fs.faults = out
+}
+
+func (fs *faultSet) clear() {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	fs.faults = nil
+}
+
+// apply iterates faults in reverse insertion order (LIFO) and returns the
+// first matching fault's effect, or nil if none match.
+func (fs *faultSet) apply(ctx context.Context, verb string, gvr schema.GroupVersionResource, namespace, name string) error {
+	fs.mu.RLock()
+	var matched Fault
+	for i := len(fs.faults) - 1; i >= 0; i-- {
+		if fs.faults[i].f.matches(verb, gvr, namespace, name) {
+			matched = fs.faults[i].f
+			break
+		}
+	}
+	fs.mu.RUnlock()
+	if matched != nil {
+		return matched.execute(ctx)
+	}
+	return nil
+}
+
+// FaultBuilder constructs a Fault with optional selectors.
+type FaultBuilder interface {
+	Fault
+	OnVerb(verb string) FaultBuilder
+	OnResource(gvr schema.GroupVersionResource) FaultBuilder
+	OnNamespace(ns string) FaultBuilder
+	OnName(name string) FaultBuilder
+}
+
+type baseFault struct {
+	verb      string // empty = match all
+	gvr       schema.GroupVersionResource
+	hasGVR    bool
+	namespace string // empty = match all
+	name      string // empty = match all
+	effectFn  func(ctx context.Context) error
+}
+
+func (b *baseFault) matches(verb string, gvr schema.GroupVersionResource, namespace, name string) bool {
+	if b.verb != "" && b.verb != verb {
+		return false
+	}
+	if b.hasGVR && b.gvr != gvr {
+		return false
+	}
+	if b.namespace != "" && b.namespace != namespace {
+		return false
+	}
+	if b.name != "" && b.name != name {
+		return false
+	}
+	return true
+}
+
+func (b *baseFault) execute(ctx context.Context) error {
+	return b.effectFn(ctx)
+}
+
+func (b *baseFault) OnVerb(verb string) FaultBuilder {
+	c := *b
+	c.verb = verb
+	return &c
+}
+
+func (b *baseFault) OnResource(gvr schema.GroupVersionResource) FaultBuilder {
+	c := *b
+	c.gvr = gvr
+	c.hasGVR = true
+	return &c
+}
+
+func (b *baseFault) OnNamespace(ns string) FaultBuilder {
+	c := *b
+	c.namespace = ns
+	return &c
+}
+
+func (b *baseFault) OnName(name string) FaultBuilder {
+	c := *b
+	c.name = name
+	return &c
+}
+
+// ErrorFault returns an error for all matching calls.
+func ErrorFault(err error) FaultBuilder {
+	return &baseFault{
+		effectFn: func(_ context.Context) error { return err },
+	}
+}
+
+// DelayFault adds latency to matching calls before forwarding them.
+//
+// In DSK tests, DelayFault blocks the current tick from completing because
+// the engine waits for all reconcile goroutines to finish via the queue
+// wrappers. For deterministic hold-and-release behaviour within a tick,
+// use HoldFault instead.
+func DelayFault(d time.Duration) FaultBuilder {
+	return &baseFault{
+		effectFn: func(ctx context.Context) error {
+			select {
+			case <-time.After(d):
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+}

--- a/dsk/fault_test.go
+++ b/dsk/fault_test.go
@@ -1,0 +1,191 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/authzed/controller-idioms/client/fake"
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+var deplGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+func TestFault_ErrorMatchingVerb(t *testing.T) {
+	d := dsk.New(t)
+	d.InjectFault(
+		dsk.ErrorFault(errors.New("simulated error")).OnVerb("patch"),
+	)
+	underlying := fake.NewClient(runtime.NewScheme())
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	_, err := client.Resource(deplGVR).Namespace("default").Patch(
+		ctx, "foo", types.MergePatchType, []byte(`{}`), metav1.PatchOptions{},
+	)
+	if err == nil || err.Error() != "simulated error" {
+		t.Fatalf("expected simulated error, got %v", err)
+	}
+}
+
+func TestFault_DoesNotMatchDifferentVerb(t *testing.T) {
+	d := dsk.New(t)
+	d.InjectFault(
+		dsk.ErrorFault(errors.New("simulated error")).OnVerb("patch"),
+	)
+	underlying := fake.NewClient(runtime.NewScheme())
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	// GET should not be faulted; the fake returns "not found" for a missing resource.
+	_, err := client.Resource(deplGVR).Namespace("default").Get(ctx, "foo", metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected not-found error from fake")
+	}
+	if err.Error() == "simulated error" {
+		t.Fatal("fault should not apply to get verb")
+	}
+}
+
+func TestFault_DelayAddsLatency(t *testing.T) {
+	d := dsk.New(t)
+	d.InjectFault(
+		dsk.DelayFault(50 * time.Millisecond).OnVerb("get"),
+	)
+	underlying := fake.NewClient(runtime.NewScheme())
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	start := time.Now()
+	client.Resource(deplGVR).Namespace("default").Get(ctx, "foo", metav1.GetOptions{})
+	elapsed := time.Since(start)
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("expected delay >= 50ms, got %v", elapsed)
+	}
+}
+
+func TestFault_HoldBlocksUntilRelease(t *testing.T) {
+	d := dsk.New(t)
+	hold, release := dsk.HoldFault()
+	d.InjectFault(hold.OnVerb("get"))
+	underlying := fake.NewClient(runtime.NewScheme())
+	client := d.Dynamic(underlying)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		client.Resource(deplGVR).Namespace("default").Get(t.Context(), "foo", metav1.GetOptions{})
+	}()
+
+	// Verify the call is blocked. synctest is not usable here: the hold fault
+	// blocks in a channel select, and release() (which unblocks it) is called
+	// from within the same scope, making the channel signable from the bubble —
+	// preventing synctest from considering the goroutine durably blocked.
+	select {
+	case <-done:
+		t.Fatal("expected call to be blocked before release")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	release()
+
+	select {
+	case <-done:
+	case <-t.Context().Done():
+		t.Fatal("call did not unblock after release")
+	}
+}
+
+func TestFault_HoldReleaseIdempotent(t *testing.T) {
+	_, release := dsk.HoldFault()
+	// Calling release multiple times must not panic.
+	release()
+	release()
+	release()
+}
+
+func TestFault_WithFaultsOption(t *testing.T) {
+	underlying := fake.NewClient(runtime.NewScheme())
+	d := dsk.New(t, dsk.WithFaults(
+		dsk.ErrorFault(errors.New("option error")).OnVerb("get"),
+	))
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	_, err := client.Resource(deplGVR).Namespace("default").Get(ctx, "foo", metav1.GetOptions{})
+	if err == nil || err.Error() != "option error" {
+		t.Fatalf("expected option error, got %v", err)
+	}
+}
+
+func TestFault_RemoveStopsFault(t *testing.T) {
+	d := dsk.New(t)
+	h := d.InjectFault(
+		dsk.ErrorFault(errors.New("simulated error")).OnVerb("get"),
+	)
+	d.RemoveFault(h)
+
+	underlying := fake.NewClient(runtime.NewScheme())
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	_, err := client.Resource(deplGVR).Namespace("default").Get(ctx, "foo", metav1.GetOptions{})
+	if err != nil && err.Error() == "simulated error" {
+		t.Fatal("fault should not apply after removal")
+	}
+}
+
+func TestFault_RemoveMiddleElement(t *testing.T) {
+	d := dsk.New(t)
+	underlying := fake.NewClient(runtime.NewScheme())
+	client := d.Dynamic(underlying)
+	ctx := t.Context()
+
+	// Inject three faults, all matching "get".
+	d.InjectFault(dsk.ErrorFault(errors.New("first fault")).OnVerb("get"))
+	h2 := d.InjectFault(dsk.ErrorFault(errors.New("second fault")).OnVerb("get"))
+	d.InjectFault(dsk.ErrorFault(errors.New("third fault")).OnVerb("get"))
+
+	// Remove the middle fault.
+	d.RemoveFault(h2)
+
+	// Third (last remaining) fault should fire first.
+	_, err := client.Resource(deplGVR).Namespace("default").Get(ctx, "foo", metav1.GetOptions{})
+	if err == nil || err.Error() != "third fault" {
+		t.Fatalf("expected third fault after removing second, got: %v", err)
+	}
+
+	// Remove third fault.
+	d.ClearFaults()
+	d.InjectFault(dsk.ErrorFault(errors.New("first fault")).OnVerb("get"))
+
+	// Only first fault remains; it should fire.
+	_, err = client.Resource(deplGVR).Namespace("default").Get(ctx, "foo", metav1.GetOptions{})
+	if err == nil || err.Error() != "first fault" {
+		t.Fatalf("expected first fault after clearing, got: %v", err)
+	}
+}
+
+func TestFault_LIFOOrdering(t *testing.T) {
+	d := dsk.New(t)
+	underlying := fake.NewClient(runtime.NewScheme())
+	client := d.Dynamic(underlying)
+
+	// Inject two faults that both match "get" on any resource.
+	d.InjectFault(dsk.ErrorFault(errors.New("first fault")).OnVerb("get"))
+	d.InjectFault(dsk.ErrorFault(errors.New("second fault")).OnVerb("get"))
+
+	// The second (last-injected) fault should fire first (LIFO).
+	ctx := t.Context()
+	_, err := client.Resource(deplGVR).Namespace("default").Get(ctx, "foo", metav1.GetOptions{})
+	if err == nil || err.Error() != "second fault" {
+		t.Fatalf("expected last-injected fault to fire first, got: %v", err)
+	}
+}

--- a/dsk/informer_dsk.go
+++ b/dsk/informer_dsk.go
@@ -1,0 +1,168 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// trackedHandler wraps a cache.ResourceEventHandler so that DSK knows when
+// each callback invocation has completed. handlerStart/handlerDone bracket
+// every On* call, letting flush() wait until all handler goroutines have
+// returned before declaring the tick window closed.
+//
+// handlerDoneCall is also called on completion: it debits the pendingCalls
+// credit that flush() set before delivering the triggering event. This ensures
+// waitForHandlersIdle blocks until all expected handler invocations are done,
+// even when the reflector goroutine hasn't started processing the event yet.
+type trackedHandler struct {
+	inner cache.ResourceEventHandler
+	eng   *engine
+}
+
+func (h *trackedHandler) OnAdd(obj any, isInInitialList bool) {
+	h.eng.handlerStart()
+	defer func() {
+		h.eng.handlerDone()
+		h.eng.handlerDoneCall()
+	}()
+	h.inner.OnAdd(obj, isInInitialList)
+}
+
+func (h *trackedHandler) OnUpdate(oldObj, newObj any) {
+	h.eng.handlerStart()
+	defer func() {
+		h.eng.handlerDone()
+		h.eng.handlerDoneCall()
+	}()
+	h.inner.OnUpdate(oldObj, newObj)
+}
+
+func (h *trackedHandler) OnDelete(obj any) {
+	h.eng.handlerStart()
+	defer func() {
+		h.eng.handlerDone()
+		h.eng.handlerDoneCall()
+	}()
+	h.inner.OnDelete(obj)
+}
+
+// compile-time check
+var _ cache.ResourceEventHandler = (*trackedHandler)(nil)
+
+// dskSharedIndexInformer wraps cache.SharedIndexInformer to intercept
+// AddEventHandler calls, wrapping each handler with trackedHandler and
+// registering the handler with its label selector so flush() can credit
+// pendingCalls correctly, filtering by selector for real-cluster informers.
+type dskSharedIndexInformer struct {
+	cache.SharedIndexInformer
+	eng       *engine
+	gvr       schema.GroupVersionResource
+	namespace string
+	selector  labels.Selector // nil for fake clients (match-all); non-nil for real clusters
+}
+
+// dskHandlerRegistration wraps a cache.ResourceEventHandlerRegistration,
+// carrying the gvr/ns/sel needed to call unregisterHandler on removal.
+type dskHandlerRegistration struct {
+	inner cache.ResourceEventHandlerRegistration
+	eng   *engine
+	gvr   schema.GroupVersionResource
+	ns    string
+	sel   labels.Selector
+}
+
+func (r *dskHandlerRegistration) HasSynced() bool { return r.inner.HasSynced() }
+
+var _ cache.ResourceEventHandlerRegistration = (*dskHandlerRegistration)(nil)
+
+func (i *dskSharedIndexInformer) addTracked(handler cache.ResourceEventHandler, addFn func(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)) (cache.ResourceEventHandlerRegistration, error) {
+	i.eng.registerHandler(i.gvr, i.namespace, i.selector)
+	reg, err := addFn(&trackedHandler{inner: handler, eng: i.eng})
+	if err != nil {
+		i.eng.unregisterHandler(i.gvr, i.namespace, i.selector)
+		return nil, err
+	}
+	return &dskHandlerRegistration{inner: reg, eng: i.eng, gvr: i.gvr, ns: i.namespace, sel: i.selector}, nil
+}
+
+func (i *dskSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return i.addTracked(handler, i.SharedIndexInformer.AddEventHandler)
+}
+
+func (i *dskSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	return i.addTracked(handler, func(h cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+		return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(h, resyncPeriod)
+	})
+}
+
+func (i *dskSharedIndexInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, opts cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	return i.addTracked(handler, func(h cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+		return i.SharedIndexInformer.AddEventHandlerWithOptions(h, opts)
+	})
+}
+
+func (i *dskSharedIndexInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
+	if dskHandle, ok := handle.(*dskHandlerRegistration); ok {
+		i.eng.unregisterHandler(dskHandle.gvr, dskHandle.ns, dskHandle.sel)
+		return i.SharedIndexInformer.RemoveEventHandler(dskHandle.inner)
+	}
+	return i.SharedIndexInformer.RemoveEventHandler(handle)
+}
+
+// dskGenericInformer wraps informers.GenericInformer so that Informer()
+// returns a handler-tracking dskSharedIndexInformer.
+type dskGenericInformer struct {
+	informers.GenericInformer
+	eng       *engine
+	gvr       schema.GroupVersionResource
+	namespace string
+	selector  labels.Selector // nil for fake clients (match-all); non-nil for real clusters
+}
+
+func (g *dskGenericInformer) Informer() cache.SharedIndexInformer {
+	return &dskSharedIndexInformer{
+		SharedIndexInformer: g.GenericInformer.Informer(),
+		eng:                 g.eng,
+		gvr:                 g.gvr,
+		namespace:           g.namespace,
+		selector:            g.selector,
+	}
+}
+
+// dskFactory wraps dynamicinformer.DynamicSharedInformerFactory so that
+// ForResource() returns a handler-tracking dskGenericInformer.
+//
+// selector is computed once at construction. For fake clients it is always nil
+// (match-all) because the fake tracker sends all events to all watchers
+// regardless of label selectors. For real clients it is derived from
+// tweakListOptions at construction time.
+type dskFactory struct {
+	dynamicinformer.DynamicSharedInformerFactory
+	eng       *engine
+	namespace string
+	selector  labels.Selector // nil for fake clients (match-all); computed once for real clients
+}
+
+func (f *dskFactory) ForResource(resource schema.GroupVersionResource) informers.GenericInformer {
+	return &dskGenericInformer{
+		GenericInformer: f.DynamicSharedInformerFactory.ForResource(resource),
+		eng:             f.eng,
+		gvr:             resource,
+		namespace:       f.namespace,
+		selector:        f.selector,
+	}
+}
+
+// compile-time checks
+var (
+	_ dynamicinformer.DynamicSharedInformerFactory = (*dskFactory)(nil)
+	_ informers.GenericInformer                    = (*dskGenericInformer)(nil)
+	_ cache.SharedIndexInformer                    = (*dskSharedIndexInformer)(nil)
+)

--- a/dsk/integration_test.go
+++ b/dsk/integration_test.go
@@ -1,0 +1,286 @@
+//go:build dsk
+
+// dsk/integration_test.go
+package dsk_test
+
+import (
+	"sync/atomic"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/authzed/controller-idioms/client/fake"
+	dsk "github.com/authzed/controller-idioms/dsk"
+	typed "github.com/authzed/controller-idioms/typed"
+)
+
+var cmGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+func TestIntegration_SteadyStateDetection(t *testing.T) {
+	// Disable WatchListClient so the informer uses traditional List+Watch.
+	// The fake object tracker does not support the watchList protocol
+	// (sendInitialEvents / BOOKMARK), so watchList hangs indefinitely.
+	t.Setenv("KUBE_FEATURE_WatchListClient", "false")
+
+	s := runtime.NewScheme()
+	corev1.AddToScheme(s)
+	underlying := fake.NewClient(s)
+
+	d := dsk.New(t)
+	client := d.Dynamic(underlying)
+	registry := dsk.NewRegistry(d)
+
+	factory := registry.MustNewFilteredDynamicSharedInformerFactory(
+		typed.NewFactoryKey("test", "cluster", "default"),
+		client, 0, "default", nil,
+	)
+
+	q := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	wrappedQ := d.WrapQueue(q)
+	defer wrappedQ.ShutDown()
+
+	var processed atomic.Int32
+
+	inf := factory.ForResource(cmGVR).Informer()
+	_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			u := obj.(*unstructured.Unstructured)
+			wrappedQ.Add(u.GetName())
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := t.Context()
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+	// Informer has synced against an empty store; watch is now open.
+
+	// Worker starts here, blocked on Get (queue is empty). When Tick delivers
+	// the Added event below, AddFunc signals the workqueue cond and the worker
+	// unblocks inside the tick's open window — so the tick tracks Get→Done and
+	// waits for the worker before declaring the tick complete.
+	requeued := make(map[string]bool)
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		for {
+			key, quit := wrappedQ.Get()
+			if quit {
+				return
+			}
+			processed.Add(1)
+			name := key.(string)
+			firstTime := !requeued[name]
+			if firstTime {
+				requeued[name] = true
+				wrappedQ.AddAfter(name, 0)
+			}
+			wrappedQ.Done(key)
+			if !firstTime {
+				return
+			}
+		}
+	}()
+
+	// Create the configmap AFTER the watch is open so the Added event is
+	// buffered by DSK. Tick delivers it, AddFunc fires (tracked by flush via
+	// pendingCalls), and the worker — already blocked on an empty queue —
+	// unblocks inside the tick window rather than racing against a pre-loaded queue.
+	_, err = client.Resource(cmGVR).Namespace("default").Create(ctx, &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": "cm1", "namespace": "default"},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d.TickUntilSteady(20)
+	<-workerDone
+
+	if processed.Load() < 2 {
+		t.Fatalf("expected processed >= 2, got %d", processed.Load())
+	}
+}
+
+func TestIntegration_OrderingMatters(t *testing.T) {
+	// Two watchers A and B both open before an object is created.
+	// Flush delivers events one at a time; we verify that the second watcher
+	// does not receive its event until after the first flush.
+	// This exercises DSK's selective Flush capability.
+	underlying := fake.NewClient(runtime.NewScheme())
+	d := dsk.New(t)
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+
+	// Open both watches BEFORE creating the object so that creation triggers
+	// an Added event on each watch stream.
+	watchA, err := client.Resource(cmGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	watchB, err := client.Resource(cmGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watchA.Stop()
+	defer watchB.Stop()
+
+	// Create the object after both watches are open. Writing through the DSK-wrapped
+	// client so Buffer() automatically waits for watch events to arrive before returning.
+	_, err = client.Resource(cmGVR).Namespace("default").Create(ctx, &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]interface{}{"name": "shared", "namespace": "default"},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := d.Buffer()
+	// Two pending events: one per watch connection.
+	if len(buf) < 2 {
+		t.Fatalf("expected >=2 buffered events, got %d", len(buf))
+	}
+
+	// Flush only the first buffered event. One of the two watchers will receive it.
+	d.Flush(buf[:1])
+
+	// Exactly one watcher should have received the event; the other should not have.
+	// We don't know which buffer slot maps to which watcher, so we check both.
+	var firstToReceive, secondWatcher watch.Interface
+	select {
+	case ev := <-watchA.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("A expected Added, got %v", ev.Type)
+		}
+		firstToReceive = watchA
+		secondWatcher = watchB
+	case ev := <-watchB.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("B expected Added, got %v", ev.Type)
+		}
+		firstToReceive = watchB
+		secondWatcher = watchA
+	case <-t.Context().Done():
+		t.Fatal("expected one watcher to receive event after partial flush")
+	}
+	_ = firstToReceive
+
+	// The second watcher should NOT have received its event yet.
+	select {
+	case <-secondWatcher.ResultChan():
+		t.Fatal("second watcher should not have received event yet")
+	default:
+	}
+
+	// Now flush the remaining buffered event.
+	d.Flush(d.Buffer())
+
+	select {
+	case ev := <-secondWatcher.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("second watcher expected Added, got %v", ev.Type)
+		}
+	case <-t.Context().Done():
+		t.Fatal("second watcher expected event after second flush")
+	}
+}
+
+func TestDSK_Registry_InformerHandlerTracking(t *testing.T) {
+	// Verifies that dsk.Registry wraps informer factories so that
+	// AddEventHandler callbacks go through trackedHandler. The informer
+	// pipeline is asynchronous (deliver → reflector → deltaFIFO → handler),
+	// so after Tick delivers the event we poll for the handler to fire.
+
+	// Disable WatchListClient so the informer uses traditional List+Watch.
+	// The fake object tracker does not support the watchList protocol
+	// (sendInitialEvents / BOOKMARK), so watchList hangs indefinitely.
+	t.Setenv("KUBE_FEATURE_WatchListClient", "false")
+
+	s := runtime.NewScheme()
+	// Register core v1 types so the fake client's List mapper knows about
+	// ConfigMapList. Without this, the informer's initial List panics.
+	corev1.AddToScheme(s)
+	underlying := fake.NewClient(s)
+
+	d := dsk.New(t)
+	client := d.Dynamic(underlying)
+	registry := dsk.NewRegistry(d)
+
+	factory := registry.MustNewFilteredDynamicSharedInformerFactory(
+		typed.NewFactoryKey("test", "cluster", "default"),
+		client,
+		0,
+		"default",
+		nil,
+	)
+
+	q := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	wrappedQ := d.WrapQueue(q)
+	defer wrappedQ.ShutDown()
+
+	var handlerCalled atomic.Int32
+	inf := factory.ForResource(cmGVR).Informer()
+	_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			handlerCalled.Add(1)
+			u := obj.(*unstructured.Unstructured)
+			wrappedQ.Add(u.GetName())
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := t.Context()
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+
+	// Create a configmap through the DSK-wrapped client.
+	_, err = client.Resource(cmGVR).Namespace("default").Create(ctx, &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": "tracked", "namespace": "default"},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tick delivers the buffered event and waits for all AddEventHandler
+	// callbacks to complete before returning. dsk.NewRegistry registers handler
+	// counts so flush() credits pendingCalls before delivery — waitForHandlersIdle
+	// blocks until the informer pipeline fires and finishes the callback. No
+	// polling needed.
+	d.Tick()
+
+	if handlerCalled.Load() == 0 {
+		t.Fatal("handler was never called — Registry wrapping may be broken")
+	}
+
+	// Drain the queue and verify steady state.
+	item, shutdown := wrappedQ.Get()
+	if shutdown {
+		t.Fatal("queue shut down unexpectedly")
+	}
+	wrappedQ.Done(item)
+
+	if !d.IsSteady() {
+		t.Fatal("expected steady after item drained")
+	}
+}

--- a/dsk/queue.go
+++ b/dsk/queue.go
@@ -1,0 +1,316 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// tickableQueue is the internal interface the engine uses to coordinate ticks
+// across registered queue wrappers. Both wrappedQueue (untyped) and
+// typedWrappedQueue[T] (generic) implement it.
+type tickableQueue interface {
+	beginTick()
+	closeWindow()
+	doneCh() <-chan struct{}
+	isIdle() bool
+	waitForIdle(ctx context.Context) error
+}
+
+// wrappedQueue wraps workqueue.RateLimitingInterface to cooperate with DSK's
+// tick engine.
+type wrappedQueue struct {
+	workqueue.RateLimitingInterface
+
+	mu         sync.Mutex
+	idleCond   *sync.Cond
+	inFlight   map[any]struct{} // keys between Get and Done dequeued during an open window
+	active     bool             // true if Add() or Get() was called during this tick window
+	windowOpen bool
+	done       chan struct{} // closed when tick is complete; reset each tick
+}
+
+func newWrappedQueue(q workqueue.RateLimitingInterface) *wrappedQueue {
+	w := &wrappedQueue{
+		RateLimitingInterface: q,
+		inFlight:              make(map[any]struct{}),
+		done:                  make(chan struct{}),
+	}
+	w.idleCond = sync.NewCond(&w.mu)
+	return w
+}
+
+// beginTick opens the Get() tracking window and resets tick state.
+// Called at the start of each Flush.
+func (w *wrappedQueue) beginTick() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.inFlight = make(map[any]struct{})
+	w.active = false
+	w.windowOpen = true
+	w.done = make(chan struct{})
+}
+
+// closeWindow closes the tick window and checks for completion.
+// Called after events are flushed and handlers have returned.
+func (w *wrappedQueue) closeWindow() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.windowOpen = false
+	w.checkDoneLocked()
+}
+
+// doneCh returns the current tick's completion channel.
+// Callers must not invoke beginTick concurrently while waiting on the returned channel.
+func (w *wrappedQueue) doneCh() <-chan struct{} {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.done
+}
+
+// isIdle returns true when there are no keys in flight and no keys pending
+// in the underlying queue. This catches items that have been requeued via
+// AddRateLimited/AddAfter and have cleared the rate limiter but not yet
+// been dequeued by a worker goroutine.
+//
+// Note: items added via AddRateLimited or AddAfter that have not yet cleared
+// the rate limiter (i.e., are still in the delay heap) are not visible to
+// Len() and are not counted here. In practice, DSK's tick model means
+// controllers call AddRateLimited with zero or near-zero delays, so this
+// window is negligible. If a controller uses significant rate-limit delays,
+// IsSteady() may return a transient false positive until the delay expires.
+func (w *wrappedQueue) isIdle() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.inFlight) == 0 && w.RateLimitingInterface.Len() == 0
+}
+
+// Add intercepts item enqueuing. Items added during an open window mark this
+// tick as active so waitForIdle knows to wait for them to be processed.
+func (w *wrappedQueue) Add(item any) {
+	w.RateLimitingInterface.Add(item)
+	w.mu.Lock()
+	if w.windowOpen {
+		w.active = true
+	}
+	w.idleCond.Broadcast()
+	w.mu.Unlock()
+}
+
+// AddRateLimited is a controller-triggered requeue. Not counted as this tick's work.
+func (w *wrappedQueue) AddRateLimited(item any) {
+	w.RateLimitingInterface.AddRateLimited(item)
+}
+
+// AddAfter is a controller-triggered requeue. Not counted as this tick's work.
+func (w *wrappedQueue) AddAfter(item any, duration time.Duration) {
+	w.RateLimitingInterface.AddAfter(item, duration)
+}
+
+// Get intercepts key dequeuing. Keys dequeued during an open window are tracked as in-flight.
+func (w *wrappedQueue) Get() (any, bool) {
+	item, shutdown := w.RateLimitingInterface.Get()
+	if !shutdown {
+		w.mu.Lock()
+		if w.windowOpen {
+			w.inFlight[item] = struct{}{}
+			w.active = true
+		}
+		// Broadcast so waitForIdle can re-check Len() now that an item was dequeued.
+		w.idleCond.Broadcast()
+		w.mu.Unlock()
+	}
+	return item, shutdown
+}
+
+// Done intercepts reconcile completion. Removes the key from in-flight tracking
+// and checks whether the tick is now complete.
+func (w *wrappedQueue) Done(item any) {
+	w.RateLimitingInterface.Done(item)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.inFlight, item)
+	w.checkDoneLocked()
+	w.idleCond.Broadcast()
+}
+
+// waitForIdle blocks until len(inFlight)==0 and Len()==0, or ctx is cancelled.
+// It only waits if the tick was active: i.e., Add() or Get() was called during
+// the tick window. Items that were already in the queue before the tick started
+// and were never touched do not trigger waiting. This ensures TickUntilSteady
+// correctly exhausts its tick budget for controllers that never drain their queue.
+//
+// Called by engine.flush after waitForHandlersIdle and before closeWindow so
+// that items requeued inside a tick (via Add by handlers, or via AddAfter/Done
+// dirty path) are drained within the same tick window rather than leaking into
+// IsSteady checks after the tick returns.
+func (w *wrappedQueue) waitForIdle(ctx context.Context) error {
+	stopCh := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			w.idleCond.Broadcast()
+		case <-stopCh:
+		}
+	}()
+	defer close(stopCh)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.active {
+		return ctx.Err()
+	}
+	for len(w.inFlight) > 0 || w.RateLimitingInterface.Len() > 0 {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		w.idleCond.Wait()
+	}
+	return ctx.Err()
+}
+
+// checkDoneLocked closes the done channel if the tick is complete:
+// window closed and nothing in flight. The tick is considered complete once
+// all items that were dequeued (Get) during the open window have been
+// finished (Done). Items sitting in the queue but never dequeued do not
+// block tick completion — use IsSteady() to detect a fully quiescent state.
+//
+// Lock ordering: w.mu is the only lock acquired here. engine.mu is
+// released before any wrappedQueue method is called, so no inversion.
+//
+// Must be called with w.mu held.
+func (w *wrappedQueue) checkDoneLocked() {
+	if !w.windowOpen && len(w.inFlight) == 0 {
+		select {
+		case <-w.done:
+			// already closed
+		default:
+			close(w.done)
+		}
+	}
+}
+
+// typedWrappedQueue is the generic counterpart of wrappedQueue for
+// controllers that use workqueue.TypedRateLimitingInterface[T] directly.
+// It implements both TypedRateLimitingInterface[T] and tickableQueue.
+type typedWrappedQueue[T comparable] struct {
+	workqueue.TypedRateLimitingInterface[T]
+
+	mu         sync.Mutex
+	idleCond   *sync.Cond
+	inFlight   map[T]struct{}
+	active     bool
+	windowOpen bool
+	done       chan struct{}
+}
+
+func newTypedWrappedQueue[T comparable](q workqueue.TypedRateLimitingInterface[T]) *typedWrappedQueue[T] {
+	w := &typedWrappedQueue[T]{
+		TypedRateLimitingInterface: q,
+		inFlight:                   make(map[T]struct{}),
+		done:                       make(chan struct{}),
+	}
+	w.idleCond = sync.NewCond(&w.mu)
+	return w
+}
+
+func (w *typedWrappedQueue[T]) beginTick() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.inFlight = make(map[T]struct{})
+	w.active = false
+	w.windowOpen = true
+	w.done = make(chan struct{})
+}
+
+func (w *typedWrappedQueue[T]) closeWindow() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.windowOpen = false
+	w.checkDoneLocked()
+}
+
+func (w *typedWrappedQueue[T]) doneCh() <-chan struct{} {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.done
+}
+
+func (w *typedWrappedQueue[T]) isIdle() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.inFlight) == 0 && w.TypedRateLimitingInterface.Len() == 0
+}
+
+func (w *typedWrappedQueue[T]) Add(item T) {
+	w.TypedRateLimitingInterface.Add(item)
+	w.mu.Lock()
+	if w.windowOpen {
+		w.active = true
+	}
+	w.idleCond.Broadcast()
+	w.mu.Unlock()
+}
+
+func (w *typedWrappedQueue[T]) Get() (T, bool) {
+	item, shutdown := w.TypedRateLimitingInterface.Get()
+	if !shutdown {
+		w.mu.Lock()
+		if w.windowOpen {
+			w.inFlight[item] = struct{}{}
+			w.active = true
+		}
+		// Broadcast so waitForIdle can re-check Len() now that an item was dequeued.
+		w.idleCond.Broadcast()
+		w.mu.Unlock()
+	}
+	return item, shutdown
+}
+
+func (w *typedWrappedQueue[T]) Done(item T) {
+	w.TypedRateLimitingInterface.Done(item)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.inFlight, item)
+	w.checkDoneLocked()
+	w.idleCond.Broadcast()
+}
+
+func (w *typedWrappedQueue[T]) checkDoneLocked() {
+	if !w.windowOpen && len(w.inFlight) == 0 {
+		select {
+		case <-w.done:
+		default:
+			close(w.done)
+		}
+	}
+}
+
+func (w *typedWrappedQueue[T]) waitForIdle(ctx context.Context) error {
+	stopCh := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			w.idleCond.Broadcast()
+		case <-stopCh:
+		}
+	}()
+	defer close(stopCh)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.active {
+		return ctx.Err()
+	}
+	for len(w.inFlight) > 0 || w.TypedRateLimitingInterface.Len() > 0 {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		w.idleCond.Wait()
+	}
+	return ctx.Err()
+}

--- a/dsk/queue_test.go
+++ b/dsk/queue_test.go
@@ -1,0 +1,132 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"testing"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestWrappedQueue_CooperativeCompletion(t *testing.T) {
+	underlying := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	defer underlying.ShutDown()
+
+	wq := newWrappedQueue(underlying)
+
+	wq.beginTick()
+
+	// Simulate informer calling Add during tick window
+	wq.Add("key1")
+
+	// Get during open window so item is tracked in inFlight
+	item, _ := wq.Get()
+	if item != "key1" {
+		t.Fatalf("expected key1, got %v", item)
+	}
+
+	// Close the window
+	wq.closeWindow()
+
+	// Before Done, tick should not be complete (item still in flight)
+	select {
+	case <-wq.doneCh():
+		t.Fatal("expected tick not complete before Done")
+	default:
+	}
+
+	wq.Done(item)
+
+	// After Done, tick should be complete
+	select {
+	case <-wq.doneCh():
+	case <-t.Context().Done():
+		t.Fatal("expected tick to complete after Done")
+	}
+}
+
+func TestWrappedQueue_RequeueNotTracked(t *testing.T) {
+	underlying := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	defer underlying.ShutDown()
+
+	wq := newWrappedQueue(underlying)
+
+	wq.beginTick()
+	wq.Add("key1")
+	wq.closeWindow()
+
+	item, _ := wq.Get()
+	// Simulate controller requeueing the key
+	wq.AddRateLimited(item)
+	wq.Done(item)
+
+	// Tick should complete — the requeue is not counted
+	select {
+	case <-wq.doneCh():
+	case <-t.Context().Done():
+		t.Fatal("expected tick to complete even with pending requeue")
+	}
+}
+
+func TestWrappedQueue_EmptyTickCompletes(t *testing.T) {
+	underlying := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	defer underlying.ShutDown()
+
+	wq := newWrappedQueue(underlying)
+
+	wq.beginTick()
+	// No Add() calls — nothing to wait for
+	wq.closeWindow()
+
+	select {
+	case <-wq.doneCh():
+	case <-t.Context().Done():
+		t.Fatal("expected empty tick to complete immediately")
+	}
+}
+
+func TestWrappedQueue_IsIdle_WithItemInUnderlyingQueue(t *testing.T) {
+	underlying := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	defer underlying.ShutDown()
+
+	wq := newWrappedQueue(underlying)
+
+	// Add directly to the underlying queue (bypassing the wrapped Add) to
+	// simulate an item that has already cleared the rate limiter and is
+	// sitting in the FIFO ready to be Get'd. Using wq.AddRateLimited would
+	// introduce timing sensitivity from the rate-limiter delay.
+	underlying.Add("key1")
+
+	if wq.isIdle() {
+		t.Fatal("expected non-idle: item is in underlying queue, waiting to be Get'd")
+	}
+
+	item, _ := wq.Get()
+	wq.Done(item)
+
+	if !wq.isIdle() {
+		t.Fatal("expected idle after item processed")
+	}
+}
+
+func TestWrappedQueue_IsIdle(t *testing.T) {
+	underlying := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	defer underlying.ShutDown()
+
+	wq := newWrappedQueue(underlying)
+	if !wq.isIdle() {
+		t.Fatal("expected idle queue to be idle")
+	}
+
+	wq.beginTick()
+	wq.Add("key1")
+	// Keep window open during Get() so item is tracked in inFlight
+	item, _ := wq.Get()
+	if wq.isIdle() {
+		t.Fatal("expected non-idle queue during inflight reconcile")
+	}
+	wq.Done(item)
+	if !wq.isIdle() {
+		t.Fatal("expected idle queue after Done")
+	}
+}

--- a/dsk/reactor.go
+++ b/dsk/reactor.go
@@ -1,0 +1,329 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// reactable is satisfied by any fake client whose reactor chain can be
+// extended — *dynamicfake.FakeDynamicClient, *k8sfake.Clientset, and
+// client/fake's *fakeDynamicClient all qualify.
+type reactable interface {
+	PrependWatchReactor(resource string, reaction k8stesting.WatchReactionFunc)
+	PrependReactor(verb, resource string, reaction k8stesting.ReactionFunc)
+	Tracker() k8stesting.ObjectTracker
+}
+
+// installReactors adds a universal watch interceptor and a write observer to
+// fake. After this call, wrap the client with wrapApply to also intercept
+// Apply/ApplyStatus, which bypass the reactor chain in client/fake.
+func installReactors(ctx context.Context, fake reactable, e *engine, fs *faultSet, tb TB) {
+	tracker := fake.Tracker()
+
+	// Watch reactor: intercepts all Watch calls, returns a ControlledWatch.
+	// Drains from the tracker's FakeWatcher so mutations still emit events.
+	fake.PrependWatchReactor("*", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		wa, ok := action.(k8stesting.WatchAction)
+		if !ok {
+			return false, nil, nil
+		}
+		gvr := wa.GetResource()
+		ns := wa.GetNamespace()
+		// name is always "" for watch calls; OnName() selectors will not match watch faults.
+		if err := fs.apply(ctx, "watch", gvr, ns, ""); err != nil {
+			return true, nil, err
+		}
+		// Pass through ListOptions so the tracker can handle sendInitialEvents
+		// (watchList protocol). Without this, the reflector's watchList never
+		// receives the required BOOKMARK and the informer cache never syncs.
+		var upstream watch.Interface
+		var err error
+		type listOptionsGetter interface {
+			GetListOptions() metav1.ListOptions
+		}
+		if lo, ok := action.(listOptionsGetter); ok {
+			opts := lo.GetListOptions()
+			upstream, err = tracker.Watch(gvr, ns, opts)
+		} else {
+			upstream, err = tracker.Watch(gvr, ns)
+		}
+		if err != nil {
+			return true, nil, err
+		}
+		// Fake tracker ignores label selectors — all events go to all watchers.
+		// Register with nil selector (match-all) so preExpectWrite counts correctly.
+		return true, interceptWatch(ctx, upstream, e, gvr, ns, nil, tb), nil
+	})
+
+	// Write observer: runs before the default ObjectReaction, calls through to
+	// it, then records the returned RV so Tick/Buffer can wait for the event.
+	//
+	// preExpectWrite is called BEFORE the write to avoid a race between
+	// event arrival in drainUpstream and the subsequent upgradeExpect/cancelPreExpect call.
+	objectReaction := k8stesting.ObjectReaction(tracker)
+	fake.PrependReactor("*", "*", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		name := actionName(action)
+		if err := fs.apply(ctx, action.GetVerb(), gvr, ns, name); err != nil {
+			return true, nil, err
+		}
+		// Pre-increment pendingAnyEvent before the write so that the drain
+		// goroutine cannot decrement before upgradeExpect/cancelPreExpect runs.
+		// Pass the object's labels so preExpectWrite can filter out watches whose
+		// selector does not match (no-op for fake clients where all watches use nil).
+		preN := e.preExpectWrite(action.GetVerb(), gvr, ns, actionObjectLabels(action))
+		handled, obj, err := objectReaction(action)
+		if preN > 0 {
+			if handled && err == nil {
+				if mo, ok := obj.(metav1.Object); ok {
+					rv := mo.GetResourceVersion()
+					if rv != "" {
+						// Upgrade to RV-based tracking; removes the pre-increment.
+						e.upgradeExpect(gvr, rv, preN)
+					}
+					// If rv == "", pendingAnyEvent stays incremented — correct.
+				} else if action.GetVerb() == "delete" {
+					// Delete is the only verb that succeeds with a nil response object.
+					// pendingAnyEvent stays incremented; it will be decremented when
+					// the DELETED watch event arrives in drainUpstream.
+				} else {
+					// Unexpected: a non-delete verb succeeded but returned no object.
+					// Cancel to avoid a permanent hang.
+					e.cancelPreExpect(gvr, preN)
+				}
+			} else {
+				e.cancelPreExpect(gvr, preN)
+			}
+		}
+		return handled, obj, err
+	})
+}
+
+// actionName extracts the object name from an action if available.
+func actionName(action k8stesting.Action) string {
+	if na, ok := action.(interface{ GetName() string }); ok {
+		return na.GetName()
+	}
+	return ""
+}
+
+// actionObjectLabels returns the label map of the object in a create or update
+// action, or nil for patch, delete, or actions without an accessible object.
+// Used by preExpectWrite to filter watches by label selector.
+func actionObjectLabels(action k8stesting.Action) map[string]string {
+	type objectGetter interface {
+		GetObject() k8sruntime.Object
+	}
+	if og, ok := action.(objectGetter); ok {
+		if meta, ok := og.GetObject().(interface{ GetLabels() map[string]string }); ok {
+			return meta.GetLabels()
+		}
+	}
+	return nil
+}
+
+// applyInterceptor wraps a dynamic.Interface to track write expectations after
+// Apply and ApplyStatus. These bypass the reactor chain in client/fake.NewClient()
+// because fakeDynamicResourceClient.Apply() calls the tracker directly without
+// going through Invoke(). All other verbs are handled by the reactor.
+//
+// tracker is held so that Apply can fall back to a direct Create/Update when
+// the underlying fake client's field-managed tracker needs scheme knowledge
+// that is not available (e.g. when runtime.NewScheme() is used in tests).
+type applyInterceptor struct {
+	dynamic.Interface
+	engine  *engine
+	tracker k8stesting.ObjectTracker
+	faults  *faultSet
+}
+
+// IsWatchListSemanticsUnSupported forwards the optional WatchList capability
+// check to the underlying client. Without this, embedding dynamic.Interface
+// hides the concrete FakeDynamicClient method, causing the reflector to assume
+// WatchList is supported and wait for a BOOKMARK that the fake tracker never sends.
+func (a *applyInterceptor) IsWatchListSemanticsUnSupported() bool {
+	type watchListChecker interface {
+		IsWatchListSemanticsUnSupported() bool
+	}
+	if c, ok := a.Interface.(watchListChecker); ok {
+		return c.IsWatchListSemanticsUnSupported()
+	}
+	return false
+}
+
+func (a *applyInterceptor) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &applyInterceptorResource{
+		NamespaceableResourceInterface: a.Interface.Resource(gvr),
+		engine:                         a.engine,
+		tracker:                        a.tracker,
+		faults:                         a.faults,
+		gvr:                            gvr,
+	}
+}
+
+type applyInterceptorResource struct {
+	dynamic.NamespaceableResourceInterface
+	engine  *engine
+	tracker k8stesting.ObjectTracker
+	faults  *faultSet
+	gvr     schema.GroupVersionResource
+}
+
+func (r *applyInterceptorResource) Namespace(ns string) dynamic.ResourceInterface {
+	return &applyInterceptorNamespacedResource{
+		ResourceInterface: r.NamespaceableResourceInterface.Namespace(ns),
+		engine:            r.engine,
+		tracker:           r.tracker,
+		faults:            r.faults,
+		gvr:               r.gvr,
+		namespace:         ns,
+	}
+}
+
+// Apply intercepts cluster-scoped Apply calls (i.e. without a prior .Namespace()
+// call). Without this override, Apply would go directly to the embedded
+// NamespaceableResourceInterface, bypassing preExpectWrite/upgradeExpect.
+func (r *applyInterceptorResource) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return doApplyWithTracking(ctx, r.faults, r.engine, r.tracker, r.gvr, "", name, obj, func() (*unstructured.Unstructured, error) {
+		return r.NamespaceableResourceInterface.Apply(ctx, name, obj, opts, subresources...)
+	})
+}
+
+// ApplyStatus intercepts cluster-scoped ApplyStatus calls (i.e. without a prior
+// .Namespace() call). Without this override, ApplyStatus would go directly to
+// the embedded NamespaceableResourceInterface, bypassing preExpectWrite/upgradeExpect.
+func (r *applyInterceptorResource) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return doApplyWithTracking(ctx, r.faults, r.engine, r.tracker, r.gvr, "", name, obj, func() (*unstructured.Unstructured, error) {
+		return r.NamespaceableResourceInterface.ApplyStatus(ctx, name, obj, opts)
+	})
+}
+
+type applyInterceptorNamespacedResource struct {
+	dynamic.ResourceInterface
+	engine    *engine
+	tracker   k8stesting.ObjectTracker
+	faults    *faultSet
+	gvr       schema.GroupVersionResource
+	namespace string
+}
+
+func (r *applyInterceptorNamespacedResource) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return doApplyWithTracking(ctx, r.faults, r.engine, r.tracker, r.gvr, r.namespace, name, obj, func() (*unstructured.Unstructured, error) {
+		return r.ResourceInterface.Apply(ctx, name, obj, opts, subresources...)
+	})
+}
+
+func (r *applyInterceptorNamespacedResource) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return doApplyWithTracking(ctx, r.faults, r.engine, r.tracker, r.gvr, r.namespace, name, obj, func() (*unstructured.Unstructured, error) {
+		return r.ResourceInterface.ApplyStatus(ctx, name, obj, opts)
+	})
+}
+
+// doApplyWithTracking wraps an Apply or ApplyStatus call with fault injection
+// and preExpectWrite/upgradeExpect tracking, falling back to trackerApply on
+// error (to support fake clients backed by runtime.NewScheme() where the
+// field-managed tracker cannot resolve the GVK).
+func doApplyWithTracking(ctx context.Context, fs *faultSet, eng *engine, tracker k8stesting.ObjectTracker, gvr schema.GroupVersionResource, namespace, name string, obj *unstructured.Unstructured, apply func() (*unstructured.Unstructured, error)) (*unstructured.Unstructured, error) {
+	if err := fs.apply(ctx, "patch", gvr, namespace, name); err != nil {
+		return nil, err
+	}
+	// Apply/ApplyStatus is a patch; labels are in obj but the final merged
+	// state is unknown before the call, so pass nil (conservative match-all).
+	preN := eng.preExpectWrite("patch", gvr, namespace, nil)
+	result, err := apply()
+	if err != nil {
+		result, err = trackerApply(tracker, gvr, namespace, name, obj)
+	}
+	if preN > 0 {
+		if err == nil {
+			if rv := result.GetResourceVersion(); rv != "" {
+				eng.upgradeExpect(gvr, rv, preN)
+			}
+			// If rv == "", pendingAnyEvent stays incremented — correct.
+		} else {
+			eng.cancelPreExpect(gvr, preN)
+		}
+	}
+	return result, err
+}
+
+// trackerApply stores obj in the plain tracker (Create if new, Update if
+// existing) and returns the stored copy. Used as a fallback when the
+// field-managed tracker is unavailable due to a missing scheme registration,
+// while still emitting watch events via the plain tracker's watcher.
+func trackerApply(tracker k8stesting.ObjectTracker, gvr schema.GroupVersionResource, namespace, name string, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	_, getErr := tracker.Get(gvr, namespace, name)
+	if apierrors.IsNotFound(getErr) {
+		if err := tracker.Create(gvr, obj, namespace); err != nil {
+			return nil, err
+		}
+	} else if getErr == nil {
+		if err := tracker.Update(gvr, obj, namespace); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, getErr
+	}
+	stored, err := tracker.Get(gvr, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	if u, ok := stored.(*unstructured.Unstructured); ok {
+		return u, nil
+	}
+	m, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(stored)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: m}, nil
+}
+
+// wrapApply wraps a fake dynamic.Interface so Apply/ApplyStatus trigger fault
+// injection and RV tracking.
+func wrapApply(underlying dynamic.Interface, e *engine, tracker k8stesting.ObjectTracker, fs *faultSet) dynamic.Interface {
+	return &applyInterceptor{Interface: underlying, engine: e, tracker: tracker, faults: fs}
+}
+
+// interceptWatch wraps an upstream watch.Interface in a ControlledWatch and
+// starts the drain goroutine. ns is the namespace this watch was opened for
+// ("" means all namespaces / cluster-scoped). sel is the label selector for
+// this watch; nil means match-all (correct for fake clients).
+func interceptWatch(ctx context.Context, upstream watch.Interface, e *engine, gvr schema.GroupVersionResource, ns string, sel labels.Selector, tb TB) *ControlledWatch {
+	cw := NewControlledWatch(tb)
+	e.registerWatch(gvr, ns, sel)
+	go drainUpstream(ctx, upstream, cw, e, gvr, ns, sel)
+	return cw
+}
+
+// drainUpstream reads events from upstream and appends them to the engine
+// buffer. Stops when ctx is done, the upstream channel closes, or cw.Stop()
+// is called.
+func drainUpstream(ctx context.Context, upstream watch.Interface, cw *ControlledWatch, e *engine, gvr schema.GroupVersionResource, ns string, sel labels.Selector) {
+	defer upstream.Stop()
+	defer e.unregisterWatch(gvr, ns, sel)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-cw.Done():
+			return
+		case ev, ok := <-upstream.ResultChan():
+			if !ok {
+				return
+			}
+			e.addToBuffer(pendingEvent{event: ev, dest: cw, gvr: gvr})
+		}
+	}
+}

--- a/dsk/reactor_test.go
+++ b/dsk/reactor_test.go
@@ -1,0 +1,100 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/authzed/controller-idioms/client/fake"
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+var reactorCmGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+// TestReactor_BuffersWatchEventsForAllResourceTypes verifies that
+// d.Dynamic(fake) buffers events for arbitrary resource types, not just pods.
+func TestReactor_BuffersWatchEventsForAllResourceTypes(t *testing.T) {
+	underlying := fake.NewClient(runtime.NewScheme())
+	d := dsk.New(t)
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	w, err := client.Resource(reactorCmGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	_, err = client.Resource(reactorCmGVR).Namespace("default").Create(ctx,
+		testConfigMap("cm1"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Event must be buffered, not immediately delivered.
+	select {
+	case <-w.ResultChan():
+		t.Fatal("event should be buffered until Tick")
+	default:
+	}
+
+	d.Tick()
+
+	select {
+	case ev := <-w.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("want Added, got %v", ev.Type)
+		}
+	case <-t.Context().Done():
+		t.Fatal("event not delivered after Tick")
+	}
+}
+
+func TestReactor_ApplyBuffersWatchEvent(t *testing.T) {
+	underlying := fake.NewClient(runtime.NewScheme())
+	d := dsk.New(t)
+	client := d.Dynamic(underlying)
+
+	ctx := t.Context()
+	w, err := client.Resource(reactorCmGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	// Apply bypasses the reactor chain in client/fake — applyInterceptor must
+	// call expectRV so that Buffer() waits for the resulting watch event.
+	_, err = client.Resource(reactorCmGVR).Namespace("default").Apply(ctx, "cm1",
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]interface{}{"name": "cm1", "namespace": "default"},
+			},
+		}, metav1.ApplyOptions{FieldManager: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Buffer() must not return until the Apply watch event has arrived.
+	buf := d.Buffer()
+	if len(buf) == 0 {
+		t.Fatal("expected Apply watch event in buffer")
+	}
+	d.Flush(buf)
+
+	select {
+	case ev := <-w.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("want Added, got %v", ev.Type)
+		}
+	case <-t.Context().Done():
+		t.Fatal("event not delivered after Flush")
+	}
+}

--- a/dsk/registry_dsk.go
+++ b/dsk/registry_dsk.go
@@ -1,0 +1,77 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+
+	"github.com/authzed/controller-idioms/typed"
+)
+
+// Registry is a DSK-aware InformerRegistry. It embeds *typed.Registry and
+// overrides factory construction to wrap each factory with dskFactory so that
+// AddEventHandler calls are intercepted and tracked by the DSK engine.
+//
+// Use dsk.NewRegistry(d) in test setup wherever typed.NewRegistry() is used
+// in production. *dsk.Registry satisfies typed.InformerRegistry.
+type Registry struct {
+	*typed.Registry
+	d *DSK
+}
+
+// NewRegistry returns a DSK-aware Registry bound to d. All informer factories
+// created through this registry will wrap their AddEventHandler calls so that
+// Flush() can wait for all handler invocations to complete.
+func NewRegistry(d *DSK) *Registry {
+	return &Registry{Registry: typed.NewRegistry(), d: d}
+}
+
+// MustNewFilteredDynamicSharedInformerFactory overrides the embedded method
+// to wrap the factory with DSK handler interception before registering it.
+func (r *Registry) MustNewFilteredDynamicSharedInformerFactory(key typed.FactoryKey, client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions dynamicinformer.TweakListOptionsFunc) dynamicinformer.DynamicSharedInformerFactory {
+	factory, err := r.NewFilteredDynamicSharedInformerFactory(key, client, defaultResync, namespace, tweakListOptions)
+	if err != nil {
+		r.d.tb.Fatalf("dsk: MustNewFilteredDynamicSharedInformerFactory: %v", err)
+		return nil
+	}
+	return factory
+}
+
+// NewFilteredDynamicSharedInformerFactory overrides the embedded method to
+// wrap the factory with DSK handler interception before registering it.
+func (r *Registry) NewFilteredDynamicSharedInformerFactory(key typed.FactoryKey, client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions dynamicinformer.TweakListOptionsFunc) (dynamicinformer.DynamicSharedInformerFactory, error) {
+	raw := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, defaultResync, namespace, tweakListOptions)
+
+	// Compute the label selector once at construction. For fake clients, always
+	// nil (match-all): the fake tracker sends all events to all watchers
+	// regardless of label selectors. For real clients, derive from tweakListOptions.
+	var sel labels.Selector
+	if _, isFake := client.(reactable); !isFake && tweakListOptions != nil {
+		opts := &metav1.ListOptions{}
+		tweakListOptions(opts)
+		if opts.LabelSelector != "" {
+			if parsed, err := labels.Parse(opts.LabelSelector); err == nil {
+				sel = parsed
+			}
+		}
+	}
+
+	wrapped := &dskFactory{
+		DynamicSharedInformerFactory: raw,
+		eng:                          r.d.engine,
+		namespace:                    namespace,
+		selector:                     sel,
+	}
+	if err := r.Registry.Add(key, wrapped); err != nil {
+		return nil, err
+	}
+	return wrapped, nil
+}
+
+// compile-time check: *Registry satisfies typed.InformerRegistry
+var _ typed.InformerRegistry = (*Registry)(nil)

--- a/dsk/testhelpers_test.go
+++ b/dsk/testhelpers_test.go
@@ -1,0 +1,33 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+func testRestConfig(t *testing.T, host string) *rest.Config {
+	t.Helper()
+	return &rest.Config{Host: host}
+}
+
+func testPod(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": name, "namespace": "default"},
+	}}
+}
+
+func testConfigMap(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": name, "namespace": "default"},
+		},
+	}
+}

--- a/dsk/transport.go
+++ b/dsk/transport.go
@@ -1,0 +1,349 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// transportCodecs is used for content-negotiated stream decoding (JSON and protobuf).
+var transportCodecs = scheme.Codecs
+
+// dskTransport wraps an http.RoundTripper to intercept watch requests (buffering
+// events) and write requests (tracking pending event arrivals via preExpectWrite).
+type dskTransport struct {
+	underlying http.RoundTripper
+	engine     *engine
+	faults     *faultSet
+	tb         TB
+}
+
+func (t *dskTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	gvr, ns, ok := gvrFromPath(req.URL.Path)
+	isWatch := req.URL.Query().Get("watch") == "true"
+
+	if ok {
+		verb := "watch"
+		if !isWatch {
+			verb = httpMethodToVerb(req.Method)
+		}
+		// Watch and list requests have no name segment in the path, so name is
+		// always "" for watches. OnName() selectors will not match watch faults.
+		name := objectNameFromPath(gvr, req.URL.Path)
+		if err := t.faults.apply(req.Context(), verb, gvr, ns, name); err != nil {
+			return nil, err
+		}
+	}
+
+	// Pre-increment pendingAnyEvent BEFORE the write to avoid a race between
+	// the response arriving and the watch event arriving.
+	// For POST and PUT we can extract the object's labels from the request body
+	// to filter watches by label selector. For PATCH and DELETE, labels are
+	// unknown at this point, so we pass nil (conservative match-all).
+	var preN int
+	if ok && !isWatch {
+		var objectLabels map[string]string
+		switch req.Method {
+		case http.MethodPost, http.MethodPut:
+			objectLabels = extractLabelsFromBody(req)
+		}
+		preN = t.engine.preExpectWrite(httpMethodToVerb(req.Method), gvr, ns, objectLabels)
+	}
+
+	resp, err := t.underlying.RoundTrip(req)
+	if err != nil {
+		if preN > 0 {
+			t.engine.cancelPreExpect(gvr, preN)
+		}
+		return nil, err
+	}
+
+	if !ok {
+		return resp, nil
+	}
+
+	// Watch: replace body with a pipe; drain upstream into engine buffer.
+	// Parse the label selector from the URL so preExpectWrite can filter writes
+	// to objects that do not match this watch's selector.
+	if isWatch {
+		pr, pw := io.Pipe()
+		sink := &streamSink{pw: pw}
+		sel := parseSelectorFromQuery(req.URL.Query().Get("labelSelector"))
+		t.engine.registerWatch(gvr, ns, sel)
+		go drainHTTPWatch(t.tb, req.Context(), resp.Body, resp.Header.Get("Content-Type"), sink, t.engine, gvr, ns, sel)
+		resp.Body = io.NopCloser(pr)
+		return resp, nil
+	}
+
+	// Write: inspect response status; cancel pre-expect if the write failed.
+	// On success, pendingAnyEvent already tracks the expected events (RV-agnostic).
+	// We deliberately do NOT call upgradeExpect here: in the HTTP transport case
+	// the watch event can arrive before we parse the response body, so upgrading
+	// to pendingRVs after the event already decremented pendingAnyEvent would
+	// re-add a non-zero pendingRVs entry and cause waitForPendingRVs to hang.
+	if preN > 0 {
+		switch req.Method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				// Write failed; no event will arrive.
+				t.engine.cancelPreExpect(gvr, preN)
+			}
+			// On success: leave pendingAnyEvent incremented; the arriving event will decrement it.
+		}
+	}
+
+	return resp, nil
+}
+
+// streamSink is the shared pipe writer for a single watch connection.
+type streamSink struct {
+	pw *io.PipeWriter
+}
+
+// rawFrameSink implements eventSink for a single watch event. It holds both
+// the pipe to write to and the raw frame bytes to write, captured at decode
+// time. The original encoding (JSON or protobuf) is preserved — no re-serialization.
+type rawFrameSink struct {
+	sink     *streamSink
+	rawFrame []byte
+	tb       TB
+}
+
+func (r *rawFrameSink) deliver(_ watch.Event) {
+	// Write returns an error only if the pipe read end is closed (watch stopped).
+	if _, err := r.sink.pw.Write(r.rawFrame); err != nil {
+		r.tb.Logf("dsk: rawFrameSink.deliver: watch stopped, dropping frame (%d bytes): %v", len(r.rawFrame), err)
+	}
+}
+
+// compile-time check
+var _ eventSink = (*rawFrameSink)(nil)
+
+// drainHTTPWatch reads framed watch events from the upstream response body,
+// buffers them in the engine, and unregisters the watch when done.
+// It uses runtime.NewClientNegotiator with the response Content-Type to support
+// both JSON and protobuf without re-serialization.
+func drainHTTPWatch(tb TB, ctx context.Context, upstream io.ReadCloser, contentType string, sink *streamSink, e *engine, gvr schema.GroupVersionResource, ns string, sel labels.Selector) {
+	var closeOnce sync.Once
+	closeUpstream := func() { closeOnce.Do(func() { upstream.Close() }) }
+	defer closeUpstream()
+	defer e.unregisterWatch(gvr, ns, sel)
+	defer sink.pw.Close()
+
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		tb.Errorf("dsk: watch for %v: cannot parse Content-Type %q: %v — watch events will not be buffered", gvr, contentType, err)
+		return
+	}
+
+	negotiator := k8sruntime.NewClientNegotiator(transportCodecs, schema.GroupVersion{})
+	// StreamDecoder returns (Decoder, Serializer, Framer, error).
+	// We only need the Serializer (streaming decoder) and Framer.
+	_, streamingSerializer, framer, err := negotiator.StreamDecoder(mediaType, params)
+	if err != nil || streamingSerializer == nil || framer == nil {
+		tb.Errorf("dsk: watch for %v: cannot negotiate stream decoder for %q: %v — watch events will not be buffered", gvr, contentType, err)
+		return
+	}
+
+	// framer.NewFrameReader returns exactly one complete frame per Read call.
+	frameReader := framer.NewFrameReader(upstream)
+	defer frameReader.Close()
+
+	// Close the upstream body when ctx is cancelled so frameReader.Read unblocks promptly.
+	ctxDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			closeUpstream()
+		case <-ctxDone:
+		}
+	}()
+	defer close(ctxDone)
+
+	// 1.5 MB matches etcd's default object size limit. Frames that exactly fill
+	// the buffer may have been truncated; the decode below will fail and log a
+	// hint pointing to the buffer size as the likely cause.
+	buf := make([]byte, 1536*1024)
+	for {
+		n, err := frameReader.Read(buf)
+		if err != nil {
+			return
+		}
+		if n == len(buf) {
+			tb.Logf("dsk: watch for %v: frame exactly filled %d-byte buffer — may be truncated; objects exceeding etcd's 1.5 MB limit will not be buffered correctly", gvr, n)
+		}
+		rawFrame := make([]byte, n)
+		copy(rawFrame, buf[:n])
+
+		var watchEvent metav1.WatchEvent
+		obj, _, decErr := streamingSerializer.Decode(rawFrame, nil, &watchEvent)
+		if decErr != nil || obj != &watchEvent {
+			tb.Logf("dsk: watch for %v: skipping malformed frame (%d bytes): %v", gvr, n, decErr)
+			continue
+		}
+		// Try to decode as a known typed object; fall back to unstructured.
+		actualObj, _, decErr := scheme.Codecs.UniversalDeserializer().Decode(watchEvent.Object.Raw, nil, nil)
+		if decErr != nil {
+			u := &unstructured.Unstructured{}
+			if jsonErr := u.UnmarshalJSON(watchEvent.Object.Raw); jsonErr != nil {
+				continue
+			}
+			actualObj = u
+		}
+		e.addToBuffer(pendingEvent{
+			event: watch.Event{Type: watch.EventType(watchEvent.Type), Object: actualObj},
+			dest:  &rawFrameSink{sink: sink, rawFrame: rawFrame, tb: tb},
+			gvr:   gvr,
+		})
+	}
+}
+
+// parseSelectorFromQuery parses a labelSelector query-parameter value into a
+// labels.Selector. Returns nil (match-all) if the string is empty or invalid.
+func parseSelectorFromQuery(labelSelector string) labels.Selector {
+	if labelSelector == "" {
+		return nil
+	}
+	sel, err := labels.Parse(labelSelector)
+	if err != nil {
+		return nil
+	}
+	return sel
+}
+
+// extractLabelsFromBody reads the request body, parses it as a Kubernetes
+// object (or any JSON with a .metadata.labels field), and returns the labels.
+// The request body is fully restored so the underlying transport can re-read it.
+// Returns nil if the body cannot be read or does not contain metadata.labels.
+func extractLabelsFromBody(req *http.Request) map[string]string {
+	if req.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
+
+	var obj struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil
+	}
+	return obj.Metadata.Labels
+}
+
+// gvrFromPath parses a Kubernetes API path into a GVR and namespace.
+// Returns ok=false for paths it cannot parse (e.g. /healthz, /version).
+//
+//	/api/{version}/namespaces/{ns}/{resource}[/{name}]
+//	/api/{version}/{resource}[/{name}]
+//	/apis/{group}/{version}/namespaces/{ns}/{resource}[/{name}]
+//	/apis/{group}/{version}/{resource}[/{name}]
+func gvrFromPath(path string) (gvr schema.GroupVersionResource, ns string, ok bool) {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api":
+		version := parts[1]
+		if len(parts) >= 5 && parts[2] == "namespaces" {
+			// /api/{version}/namespaces/{ns}/{resource}[/{name}...]
+			return schema.GroupVersionResource{Version: version, Resource: parts[4]}, parts[3], true
+		}
+		if parts[2] != "namespaces" {
+			// /api/{version}/{resource}[/{name}...]
+			return schema.GroupVersionResource{Version: version, Resource: parts[2]}, "", true
+		}
+		// /api/{version}/namespaces          (collection)
+		// /api/{version}/namespaces/{name}   (specific namespace object)
+		// Both are the cluster-scoped "namespaces" resource.
+		return schema.GroupVersionResource{Version: version, Resource: "namespaces"}, "", true
+	case len(parts) >= 4 && parts[0] == "apis":
+		group, version := parts[1], parts[2]
+		if len(parts) >= 6 && parts[3] == "namespaces" {
+			return schema.GroupVersionResource{Group: group, Version: version, Resource: parts[5]}, parts[4], true
+		}
+		if len(parts) >= 4 && parts[3] != "namespaces" {
+			return schema.GroupVersionResource{Group: group, Version: version, Resource: parts[3]}, "", true
+		}
+		// /apis/{group}/{version}/namespaces[/{name}] is not a valid resource path
+		// in the named-group API (unlike /api/v1/namespaces, which is the cluster-scoped
+		// namespaces resource in the core group). Fall through to return ok=false.
+	}
+	return schema.GroupVersionResource{}, "", false
+}
+
+func httpMethodToVerb(method string) string {
+	switch method {
+	case http.MethodGet:
+		return "get"
+	case http.MethodPost:
+		return "create"
+	case http.MethodPut:
+		return "update"
+	case http.MethodPatch:
+		return "patch"
+	case http.MethodDelete:
+		return "delete"
+	default:
+		return strings.ToLower(method)
+	}
+}
+
+// objectNameFromPath returns the object name for a named Kubernetes API request,
+// correctly handling subresource paths by returning the name segment rather than
+// the subresource segment.
+//
+// /api/v1/namespaces/{ns}/pods/{name}           → "name"
+// /api/v1/namespaces/{ns}/pods/{name}/status    → "name" (not "status")
+// /api/v1/nodes/{name}                          → "name"
+//
+// Returns "" for collection requests (no object name) or unrecognised paths.
+func objectNameFromPath(gvr schema.GroupVersionResource, path string) string {
+	// A named request is one where the path extends beyond the resource collection
+	// by at least one segment (the object name). A subresource request extends by two.
+	// We want the first extra segment (the object name), not the subresource.
+	//
+	// /api/v1/namespaces/{ns}/pods/{name}           → parts after resource: ["name"]
+	// /api/v1/namespaces/{ns}/pods/{name}/status    → parts after resource: ["name", "status"]
+	// /api/v1/nodes/{name}                          → parts after resource: ["name"]
+	//
+	// Parse the resource collection path length and index into parts accordingly.
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	// Determine how many parts the "base" collection path occupies.
+	var baseLen int
+	switch {
+	case len(parts) >= 5 && parts[0] == "api" && parts[2] == "namespaces":
+		baseLen = 5 // api / version / namespaces / ns / resource
+	case len(parts) >= 3 && parts[0] == "api":
+		baseLen = 3 // api / version / resource
+	case len(parts) >= 6 && parts[0] == "apis" && parts[3] == "namespaces":
+		baseLen = 6 // apis / group / version / namespaces / ns / resource
+	case len(parts) >= 4 && parts[0] == "apis":
+		baseLen = 4 // apis / group / version / resource
+	default:
+		return ""
+	}
+	if len(parts) > baseLen {
+		return parts[baseLen] // object name
+	}
+	return "" // collection request (no object name)
+}

--- a/dsk/transport_test.go
+++ b/dsk/transport_test.go
@@ -1,0 +1,467 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+var transportCmGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+// fakeWatchServer returns a minimal HTTP server that:
+// - On GET ?watch=true: immediately streams one watch event then blocks
+// - On POST: returns a created object with a resourceVersion
+func fakeWatchServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("watch") == "true" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			flusher := w.(http.Flusher)
+			w.Write([]byte(`{"type":"ADDED","object":{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"42"}}}` + "\n"))
+			flusher.Flush()
+			<-r.Context().Done()
+			return
+		}
+		// POST (create)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"42"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// fakeWriteTriggeredWatchServer returns a server where:
+// - On GET ?watch=true: sends headers immediately, waits for POST trigger, then streams event
+// - On POST: signals the watch to emit one event with the given RV, then responds
+func fakeWriteTriggeredWatchServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	trigger := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("watch") == "true" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// Flush headers immediately so Watch() call can return.
+			flusher := w.(http.Flusher)
+			flusher.Flush()
+			// Wait for the POST to trigger before streaming the event.
+			select {
+			case <-trigger:
+				w.Write([]byte(`{"type":"ADDED","object":{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"42"}}}` + "\n"))
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+			<-r.Context().Done()
+			return
+		}
+		// POST (create): signal watcher, then respond
+		select {
+		case trigger <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"42"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestTransport_BuffersWatchEvents(t *testing.T) {
+	srv := fakeWatchServer(t)
+	cfg := testRestConfig(t, srv.URL)
+
+	d := dsk.New(t)
+	dynClient, err := d.DynamicFromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w, err := dynClient.Resource(transportCmGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer w.Stop()
+
+		// Wait for the drain goroutine to process the event and buffer it.
+		// WaitForEvents uses sync.Cond.Wait which is durably blocking for synctest,
+		// avoiding the hang that synctest.Wait() would cause due to network I/O.
+		d.WaitForEvents(1)
+
+		buf := d.Buffer()
+		if len(buf) == 0 {
+			t.Fatal("expected buffered event after drain goroutine settled")
+		}
+		d.Flush(buf)
+
+		select {
+		case ev := <-w.ResultChan():
+			if ev.Type != watch.Added {
+				t.Fatalf("want Added, got %v", ev.Type)
+			}
+		case <-t.Context().Done():
+			t.Fatal("event not delivered after Flush")
+		}
+	})
+}
+
+func TestTransport_ExpectsRVAfterWrite(t *testing.T) {
+	srv := fakeWriteTriggeredWatchServer(t)
+	cfg := testRestConfig(t, srv.URL)
+
+	d := dsk.New(t)
+	dynClient, err := d.DynamicFromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := t.Context()
+	// Open a watch so watchCounts > 0 (expectRV is no-op otherwise)
+	w, err := dynClient.Resource(transportCmGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	// Create should call expectRV("42", configmapGVR)
+	_, err = dynClient.Resource(transportCmGVR).Namespace("default").Create(ctx,
+		testConfigMap("cm1"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Buffer() waits for the RV — should not block forever
+	buf := d.Buffer()
+	if len(buf) == 0 {
+		t.Fatal("expected at least one buffered event")
+	}
+}
+
+// fakeDeleteTriggeredWatchServer returns a server where:
+// - On GET ?watch=true: sends headers immediately, waits for DELETE trigger, then streams a DELETED event
+// - On POST: creates the object (so there is something to delete)
+// - On DELETE: signals the watch to emit a DELETED event, then responds
+func fakeDeleteTriggeredWatchServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	deleteReceived := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("watch") == "true" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			flusher := w.(http.Flusher)
+			flusher.Flush()
+			// Wait for DELETE to be signaled, then emit the DELETED event.
+			select {
+			case <-deleteReceived:
+				io.WriteString(w, `{"type":"DELETED","object":{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"43"}}}`+"\n") //nolint:errcheck
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+			<-r.Context().Done()
+			return
+		}
+		if r.Method == http.MethodDelete {
+			// Signal the watch handler to emit the DELETED event.
+			select {
+			case <-deleteReceived:
+				// already closed; nothing to do
+			default:
+				close(deleteReceived)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck
+			return
+		}
+		// POST (create)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"42"}}`)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestTransport_DeleteTriggersWatchEvent(t *testing.T) {
+	srv := fakeDeleteTriggeredWatchServer(t)
+	// Disable HTTP keepalives so the DELETE connection's readLoop goroutine exits
+	// promptly after the response is consumed. Without this, the readLoop joins the
+	// synctest bubble and blocks in keepalive-wait, preventing synctest.Test from
+	// returning (synctest.Test waits for all bubble goroutines to exit).
+	cfg := &rest.Config{
+		Host: srv.URL,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}
+
+	d := dsk.New(t)
+	dynClient, err := d.DynamicFromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w, err := dynClient.Resource(transportCmGVR).Namespace("default").Watch(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer w.Stop()
+
+		// registerWatch is called synchronously in RoundTrip before the drain
+		// goroutine starts, so the watch is registered by the time Watch() returns.
+		// No additional synchronization is needed before issuing the Delete.
+
+		err = dynClient.Resource(transportCmGVR).Namespace("default").Delete(ctx, "cm1", metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Buffer waits for the DELETED event via pendingAnyEvent tracking.
+		buf := d.Buffer()
+		if len(buf) != 1 {
+			t.Fatalf("expected 1 DELETED event in buffer, got %d", len(buf))
+		}
+		if buf[0].Type != watch.Deleted {
+			t.Fatalf("expected Deleted event, got %v", buf[0].Type)
+		}
+	})
+}
+
+func TestTransport_TypedBuffersWatchEvents(t *testing.T) {
+	srv := fakeWatchServer(t)
+	cfg := &rest.Config{Host: srv.URL}
+
+	d := dsk.New(t)
+	typedClient, err := d.TypedFromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w, err := typedClient.CoreV1().Pods("default").Watch(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer w.Stop()
+
+		// Wait for the drain goroutine to buffer the event.
+		d.WaitForEvents(1)
+
+		buf := d.Buffer()
+		if len(buf) == 0 {
+			t.Fatal("event not buffered after drain goroutine settled")
+		}
+		d.Flush(buf)
+
+		select {
+		case ev := <-w.ResultChan():
+			if ev.Type != watch.Added {
+				t.Fatalf("want Added, got %v", ev.Type)
+			}
+		case <-t.Context().Done():
+			t.Fatal("event not delivered after Flush")
+		}
+	})
+}
+
+func TestTransport_WatchFaultFires(t *testing.T) {
+	watchErr := errors.New("simulated watch error")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If the transport lets the request through, return a valid watch response.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := testRestConfig(t, srv.URL)
+	d := dsk.New(t, dsk.WithFaults(
+		dsk.ErrorFault(watchErr).OnVerb("watch"),
+	))
+	client, err := d.DynamicFromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Resource(transportCmGVR).Namespace("default").Watch(t.Context(), metav1.ListOptions{})
+	if !errors.Is(err, watchErr) {
+		t.Fatalf("expected watch fault error %q, got %v", watchErr, err)
+	}
+}
+
+// TestFault_HoldUnblocksOnContextCancel verifies that cancelling the per-request
+// context unblocks a HoldFault in the transport path. The reactor (fake client)
+// path does not expose the per-request context to reactors, so this must be
+// tested via DynamicFromConfig.
+func TestFault_HoldUnblocksOnContextCancel(t *testing.T) {
+	// Minimal server that blocks GET requests until the client disconnects.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	d := dsk.New(t)
+	hold, _ := dsk.HoldFault()
+	d.InjectFault(hold.OnVerb("get"))
+
+	client, err := d.DynamicFromConfig(testRestConfig(t, srv.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Resource(transportCmGVR).Namespace("default").Get(ctx, "cm1", metav1.GetOptions{})
+		done <- err
+	}()
+
+	// Verify the call is blocked. synctest cannot be used here: the hold fault
+	// blocks in a select on ctx.Done(), and cancel() (which fires ctx.Done()) is
+	// called from the same scope, making the channel signable from the bubble —
+	// preventing synctest from considering the goroutine durably blocked.
+	select {
+	case <-done:
+		t.Fatal("expected call to be blocked before cancel")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error after context cancel, got nil")
+		}
+	case <-t.Context().Done():
+		t.Fatal("call did not unblock after context cancel")
+	}
+}
+
+func TestGVRFromPath(t *testing.T) {
+	podsGVR := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	nodesGVR := schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
+	deploysGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	crdsGVR := schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
+
+	tests := []struct {
+		path    string
+		wantGVR schema.GroupVersionResource
+		wantNS  string
+		wantOK  bool
+	}{
+		// core group, namespaced
+		{"/api/v1/namespaces/default/pods", podsGVR, "default", true},
+		{"/api/v1/namespaces/kube-system/pods", podsGVR, "kube-system", true},
+		// core group, namespaced with object name
+		{"/api/v1/namespaces/default/pods/mypod", podsGVR, "default", true},
+		// core group, namespaced, subresource
+		{"/api/v1/namespaces/default/pods/mypod/status", podsGVR, "default", true},
+		// core group, cluster-scoped
+		{"/api/v1/nodes", nodesGVR, "", true},
+		{"/api/v1/nodes/mynode", nodesGVR, "", true},
+		// named group, namespaced
+		{"/apis/apps/v1/namespaces/default/deployments", deploysGVR, "default", true},
+		{"/apis/apps/v1/namespaces/default/deployments/myapp", deploysGVR, "default", true},
+		// named group, cluster-scoped
+		{"/apis/apiextensions.k8s.io/v1/customresourcedefinitions", crdsGVR, "", true},
+		{"/apis/apiextensions.k8s.io/v1/customresourcedefinitions/foo.example.com", crdsGVR, "", true},
+		// namespaces resource — collection and specific object are both the cluster-scoped namespaces resource
+		{"/api/v1/namespaces", schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}, "", true},
+		{"/api/v1/namespaces/default", schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}, "", true},
+		// /apis/{group}/{version}/namespaces is not a valid resource path — the
+		// "namespaces" resource only exists under /api/v1/. Group-versioned APIs
+		// that happen to be named "namespaces" would require a /apis/.../namespaces/{ns}/{resource}
+		// path which is handled above.
+		{"/apis/apps/v1/namespaces", schema.GroupVersionResource{}, "", false},
+		// non-resource paths
+		{"/healthz", schema.GroupVersionResource{}, "", false},
+		{"/version", schema.GroupVersionResource{}, "", false},
+		{"/metrics", schema.GroupVersionResource{}, "", false},
+		{"", schema.GroupVersionResource{}, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			gotGVR, gotNS, gotOK := dsk.GVRFromPath(tt.path)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok: got %v, want %v", gotOK, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if gotGVR != tt.wantGVR {
+				t.Errorf("gvr: got %v, want %v", gotGVR, tt.wantGVR)
+			}
+			if gotNS != tt.wantNS {
+				t.Errorf("ns: got %q, want %q", gotNS, tt.wantNS)
+			}
+		})
+	}
+}
+
+func TestObjectNameFromPath(t *testing.T) {
+	podsGVR := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	nodesGVR := schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
+	deploysGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	tests := []struct {
+		path     string
+		gvr      schema.GroupVersionResource
+		wantName string
+	}{
+		// collection (no object name)
+		{"/api/v1/namespaces/default/pods", podsGVR, ""},
+		{"/api/v1/nodes", nodesGVR, ""},
+		{"/apis/apps/v1/namespaces/default/deployments", deploysGVR, ""},
+		// named object
+		{"/api/v1/namespaces/default/pods/mypod", podsGVR, "mypod"},
+		{"/api/v1/nodes/mynode", nodesGVR, "mynode"},
+		{"/apis/apps/v1/namespaces/default/deployments/myapp", deploysGVR, "myapp"},
+		// subresource — should return the object name, not the subresource segment
+		{"/api/v1/namespaces/default/pods/mypod/status", podsGVR, "mypod"},
+		{"/api/v1/namespaces/default/pods/mypod/log", podsGVR, "mypod"},
+		{"/apis/apps/v1/namespaces/default/deployments/myapp/scale", deploysGVR, "myapp"},
+		// unrecognised path
+		{"/healthz", podsGVR, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := dsk.ObjectNameFromPath(tt.gvr, tt.path)
+			if got != tt.wantName {
+				t.Errorf("got %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}

--- a/dsk/typed_queue_test.go
+++ b/dsk/typed_queue_test.go
@@ -1,0 +1,119 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"testing"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestTypedWrappedQueue_CooperativeCompletion(t *testing.T) {
+	underlying := workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer underlying.ShutDown()
+
+	wq := newTypedWrappedQueue(underlying)
+
+	wq.beginTick()
+
+	wq.Add("key1")
+
+	item, _ := wq.Get()
+	if item != "key1" {
+		t.Fatalf("expected key1, got %v", item)
+	}
+
+	wq.closeWindow()
+
+	select {
+	case <-wq.doneCh():
+		t.Fatal("expected tick not complete before Done")
+	default:
+	}
+
+	wq.Done(item)
+
+	select {
+	case <-wq.doneCh():
+	case <-t.Context().Done():
+		t.Fatal("expected tick to complete after Done")
+	}
+}
+
+func TestTypedWrappedQueue_RequeueNotTracked(t *testing.T) {
+	underlying := workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer underlying.ShutDown()
+
+	wq := newTypedWrappedQueue(underlying)
+
+	wq.beginTick()
+	wq.Add("key1")
+	wq.closeWindow()
+
+	item, _ := wq.Get()
+	wq.AddRateLimited(item)
+	wq.Done(item)
+
+	select {
+	case <-wq.doneCh():
+	case <-t.Context().Done():
+		t.Fatal("expected tick to complete even with pending requeue")
+	}
+}
+
+func TestTypedWrappedQueue_EmptyTickCompletes(t *testing.T) {
+	underlying := workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer underlying.ShutDown()
+
+	wq := newTypedWrappedQueue(underlying)
+
+	wq.beginTick()
+	wq.closeWindow()
+
+	select {
+	case <-wq.doneCh():
+	case <-t.Context().Done():
+		t.Fatal("expected empty tick to complete immediately")
+	}
+}
+
+func TestTypedWrappedQueue_IsIdle_WithItemInUnderlyingQueue(t *testing.T) {
+	underlying := workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer underlying.ShutDown()
+
+	wq := newTypedWrappedQueue(underlying)
+
+	underlying.Add("key1")
+
+	if wq.isIdle() {
+		t.Fatal("expected non-idle: item is in underlying queue, waiting to be Get'd")
+	}
+
+	item, _ := wq.Get()
+	wq.Done(item)
+
+	if !wq.isIdle() {
+		t.Fatal("expected idle after item processed")
+	}
+}
+
+func TestTypedWrappedQueue_IsIdle(t *testing.T) {
+	underlying := workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer underlying.ShutDown()
+
+	wq := newTypedWrappedQueue(underlying)
+	if !wq.isIdle() {
+		t.Fatal("expected idle queue to be idle")
+	}
+
+	wq.beginTick()
+	wq.Add("key1")
+	item, _ := wq.Get()
+	if wq.isIdle() {
+		t.Fatal("expected non-idle queue during inflight reconcile")
+	}
+	wq.Done(item)
+	if !wq.isIdle() {
+		t.Fatal("expected idle queue after Done")
+	}
+}

--- a/dsk/typed_test.go
+++ b/dsk/typed_test.go
@@ -1,0 +1,54 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+func TestTypedWrapper_BuffersWatchEvents(t *testing.T) {
+	underlying := k8sfake.NewSimpleClientset()
+	d := dsk.New(t)
+	client := d.Typed(underlying)
+
+	ctx := t.Context()
+
+	w, err := client.CoreV1().Pods("default").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	// Write through the DSK-wrapped client so expectRV fires.
+	_, err = client.CoreV1().Pods("default").Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Event must be buffered, not immediately delivered.
+	select {
+	case <-w.ResultChan():
+		t.Fatal("expected event to be buffered, not delivered")
+	default:
+	}
+
+	d.Tick()
+
+	select {
+	case ev := <-w.ResultChan():
+		if ev.Type != watch.Added {
+			t.Fatalf("expected Added, got %v", ev.Type)
+		}
+	case <-t.Context().Done():
+		t.Fatal("expected event after Tick")
+	}
+}

--- a/dsk/watch.go
+++ b/dsk/watch.go
@@ -1,0 +1,105 @@
+//go:build dsk
+
+package dsk
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ControlledWatch implements watch.Interface with DSK-controlled event delivery.
+// Events are only sent to ResultChan when Deliver is called explicitly.
+type ControlledWatch struct {
+	resultCh chan watch.Event
+	// stopCh is closed by Stop() to signal the upstream drain goroutine to exit.
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	// mu guards stopped and coordinates with wg to prevent close(resultCh) racing with Deliver.
+	mu      sync.Mutex
+	stopped bool // true after Stop() is called; checked by Deliver before wg.Add
+	// wg tracks in-flight Deliver calls; Stop waits for it before closing resultCh.
+	wg sync.WaitGroup
+	tb TB
+}
+
+// NewControlledWatch creates a new ControlledWatch ready for use.
+// The channel is unbuffered: Deliver blocks until the consumer reads from ResultChan
+// or Stop is called. In practice the consumer (informer reflector) runs in its own
+// goroutine, so Deliver only blocks until the next goroutine scheduling point.
+func NewControlledWatch(tb TB) *ControlledWatch {
+	return &ControlledWatch{
+		resultCh: make(chan watch.Event),
+		stopCh:   make(chan struct{}),
+		tb:       tb,
+	}
+}
+
+// ResultChan returns the channel that delivers watch events to the consumer.
+// Implements watch.Interface.
+func (w *ControlledWatch) ResultChan() <-chan watch.Event {
+	return w.resultCh
+}
+
+// Stop signals the upstream drain goroutine to exit and closes the result
+// channel, signalling the consumer that the watch ended.
+// Implements watch.Interface. Safe to call multiple times.
+func (w *ControlledWatch) Stop() {
+	w.stopOnce.Do(func() {
+		// Mark stopped under the lock so Deliver can't start a new wg.Add after
+		// we call wg.Wait().
+		w.mu.Lock()
+		w.stopped = true
+		w.mu.Unlock()
+
+		close(w.stopCh) // unblocks any Deliver call waiting in its blocking select
+		w.wg.Wait()     // wait for all in-flight Deliver calls to finish
+		close(w.resultCh)
+	})
+}
+
+// Done returns a channel that is closed when Stop() is called.
+// Use this to detect watch termination without participating in the Deliver WaitGroup.
+func (w *ControlledWatch) Done() <-chan struct{} {
+	return w.stopCh
+}
+
+// Deliver writes ev to the result channel. Deliver blocks until the consumer
+// reads from ResultChan or the watch is stopped via Stop().
+// A stopped watch drops the event and logs a diagnostic message.
+func (w *ControlledWatch) Deliver(ev watch.Event) {
+	// Atomically check stopped and increment wg so that Stop() cannot close
+	// resultCh between our stopped-check and our send.
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		w.tb.Logf("dsk: Deliver called on stopped watch — event %v dropped", ev.Type)
+		return
+	}
+	w.wg.Add(1)
+	w.mu.Unlock()
+	defer w.wg.Done()
+
+	// Block until the consumer reads or the watch is stopped.
+	select {
+	case w.resultCh <- ev:
+	case <-w.stopCh:
+		// Watch stopped while blocking; event dropped.
+		w.tb.Logf("dsk: Deliver unblocked by Stop() — event %v dropped", ev.Type)
+	case <-w.tb.Context().Done():
+		// Test ended while delivery was still pending. This typically means
+		// Flush/Tick was called without a concurrent consumer reading from
+		// ResultChan (e.g. no running informer reflector goroutine).
+		w.tb.Logf("dsk: event %v was never consumed — ResultChan() must be "+
+			"read concurrently with Flush/Tick; check that an informer reflector "+
+			"goroutine is running when Tick/Flush is called", ev.Type)
+	}
+}
+
+// deliver implements eventSink. Called by engine.flush to push ev to the result channel.
+func (w *ControlledWatch) deliver(ev watch.Event) {
+	w.Deliver(ev)
+}
+
+// compile-time check
+var _ eventSink = (*ControlledWatch)(nil)

--- a/dsk/watch_test.go
+++ b/dsk/watch_test.go
@@ -1,0 +1,93 @@
+//go:build dsk
+
+package dsk_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/watch"
+
+	dsk "github.com/authzed/controller-idioms/dsk"
+)
+
+func TestControlledWatch_DeliverSendsEvent(t *testing.T) {
+	cw := dsk.NewControlledWatch(t)
+	ev := watch.Event{Type: watch.Added}
+
+	// ResultChan should not have events before delivery
+	select {
+	case <-cw.ResultChan():
+		t.Fatal("expected no event before delivery")
+	default:
+	}
+
+	// Deliver from a goroutine since the channel is unbuffered
+	go cw.Deliver(ev)
+
+	got := <-cw.ResultChan()
+	if got.Type != watch.Added {
+		t.Fatalf("expected Added, got %v", got.Type)
+	}
+}
+
+func TestControlledWatch_StopClosesChannel(t *testing.T) {
+	cw := dsk.NewControlledWatch(t)
+	cw.Stop()
+
+	_, ok := <-cw.ResultChan()
+	if ok {
+		t.Fatal("expected channel to be closed after Stop")
+	}
+}
+
+// TestControlledWatch_DeliverBlocksWhenNoConsumer verifies that the channel is
+// unbuffered: Deliver must block until a consumer reads from ResultChan.
+func TestControlledWatch_DeliverBlocksWhenNoConsumer(t *testing.T) {
+	cw := dsk.NewControlledWatch(t)
+
+	deliverDone := make(chan struct{})
+	go func() {
+		defer close(deliverDone)
+		cw.Deliver(watch.Event{Type: watch.Added})
+	}()
+
+	// Verify Deliver is blocking (no consumer).
+	select {
+	case <-deliverDone:
+		t.Fatal("expected Deliver to block when no consumer is reading")
+	default:
+	}
+
+	// Drain one event — Deliver should unblock.
+	<-cw.ResultChan()
+	select {
+	case <-deliverDone:
+	case <-t.Context().Done():
+		t.Fatal("expected Deliver to complete after consumer drained")
+	}
+}
+
+func TestControlledWatch_DeliverReturnsOnStop(t *testing.T) {
+	cw := dsk.NewControlledWatch(t)
+
+	deliverDone := make(chan struct{})
+	go func() {
+		defer close(deliverDone)
+		cw.Deliver(watch.Event{Type: watch.Modified})
+	}()
+
+	// Verify the goroutine is blocking before calling Stop.
+	select {
+	case <-deliverDone:
+		t.Fatal("expected Deliver to block when no consumer is reading")
+	default:
+	}
+
+	cw.Stop()
+
+	select {
+	case <-deliverDone:
+	case <-t.Context().Done():
+		t.Fatal("expected Deliver to return after Stop()")
+	}
+}

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -19,7 +19,7 @@ func (t Test) All() error {
 // Unit Runs the unit tests
 func (Test) Unit() error {
 	fmt.Println("running unit tests")
-	return goTest("./...")
+	return goTest("./...", "-tags", "dsk")
 }
 
 // Integration Run integration tests

--- a/manager/controller.go
+++ b/manager/controller.go
@@ -88,14 +88,14 @@ type OwnedResourceController struct {
 	*BasicController
 	log logr.Logger
 	queue.OperationsContext
-	Registry *typed.Registry
+	Registry typed.InformerRegistry
 	Recorder record.EventRecorder
 	Owned    schema.GroupVersionResource
 	Queue    workqueue.TypedRateLimitingInterface[string]
 	sync     SyncFunc
 }
 
-func NewOwnedResourceController(log logr.Logger, name string, owned schema.GroupVersionResource, key queue.OperationsContext, registry *typed.Registry, broadcaster record.EventBroadcaster, syncFunc SyncFunc) *OwnedResourceController {
+func NewOwnedResourceController(log logr.Logger, name string, owned schema.GroupVersionResource, key queue.OperationsContext, registry typed.InformerRegistry, broadcaster record.EventBroadcaster, syncFunc SyncFunc) *OwnedResourceController {
 	return &OwnedResourceController{
 		log:               log,
 		BasicController:   NewBasicController(name),

--- a/typed/registry.go
+++ b/typed/registry.go
@@ -65,6 +65,26 @@ type Registry struct {
 	factories map[any]dynamicinformer.DynamicSharedInformerFactory
 }
 
+// InformerRegistry is the interface satisfied by Registry. Accepting
+// InformerRegistry instead of *Registry allows test code to substitute
+// a DSK-aware implementation without changing controller signatures.
+type InformerRegistry interface {
+	MustNewFilteredDynamicSharedInformerFactory(key FactoryKey, client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions dynamicinformer.TweakListOptionsFunc) dynamicinformer.DynamicSharedInformerFactory
+	NewFilteredDynamicSharedInformerFactory(key FactoryKey, client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions dynamicinformer.TweakListOptionsFunc) (dynamicinformer.DynamicSharedInformerFactory, error)
+	Add(key FactoryKey, factory dynamicinformer.DynamicSharedInformerFactory) error
+	Remove(key FactoryKey)
+	MustInformerFactoryForKey(key RegistryKey) informers.GenericInformer
+	InformerFactoryForKey(key RegistryKey) (informers.GenericInformer, error)
+	MustInformerForKey(key RegistryKey) cache.SharedIndexInformer
+	InformerForKey(key RegistryKey) (cache.SharedIndexInformer, error)
+	MustListerForKey(key RegistryKey) cache.GenericLister
+	ListerForKey(key RegistryKey) (cache.GenericLister, error)
+	MustIndexerForKey(key RegistryKey) cache.Indexer
+	IndexerForKey(key RegistryKey) (cache.Indexer, error)
+}
+
+var _ InformerRegistry = (*Registry)(nil)
+
 // NewRegistry returns a new, empty Registry
 func NewRegistry() *Registry {
 	return &Registry{
@@ -96,17 +116,17 @@ func (r *Registry) NewFilteredDynamicSharedInformerFactory(key FactoryKey, clien
 // ListerFor returns a typed Lister from a Registry
 //
 // Deprecated: Use MustListerForKey instead
-func ListerFor[K runtime.Object](r *Registry, key RegistryKey) *Lister[K] {
+func ListerFor[K runtime.Object](r InformerRegistry, key RegistryKey) *Lister[K] {
 	return MustListerForKey[K](r, key)
 }
 
 // MustListerForKey returns a typed Lister from a Registry, or panics if the key is not found
-func MustListerForKey[K runtime.Object](r *Registry, key RegistryKey) *Lister[K] {
+func MustListerForKey[K runtime.Object](r InformerRegistry, key RegistryKey) *Lister[K] {
 	return NewLister[K](r.MustListerForKey(key))
 }
 
 // ListerForKey returns a typed Lister from a Registry, or an error if the key is not found
-func ListerForKey[K runtime.Object](r *Registry, key RegistryKey) (*Lister[K], error) {
+func ListerForKey[K runtime.Object](r InformerRegistry, key RegistryKey) (*Lister[K], error) {
 	lister, err := r.ListerForKey(key)
 	if err != nil {
 		return nil, err
@@ -117,17 +137,17 @@ func ListerForKey[K runtime.Object](r *Registry, key RegistryKey) (*Lister[K], e
 // IndexerFor returns a typed Indexer from a Registry
 //
 // Deprecated: Use MustIndexerForKey instead
-func IndexerFor[K runtime.Object](r *Registry, key RegistryKey) *Indexer[K] {
+func IndexerFor[K runtime.Object](r InformerRegistry, key RegistryKey) *Indexer[K] {
 	return MustIndexerForKey[K](r, key)
 }
 
 // MustIndexerForKey returns a typed Indexer from a Registry, or panics if the key is not found
-func MustIndexerForKey[K runtime.Object](r *Registry, key RegistryKey) *Indexer[K] {
+func MustIndexerForKey[K runtime.Object](r InformerRegistry, key RegistryKey) *Indexer[K] {
 	return NewIndexer[K](r.MustIndexerForKey(key))
 }
 
 // IndexerForKey returns a typed Indexer from a Registry, or an error if the key is not found
-func IndexerForKey[K runtime.Object](r *Registry, key RegistryKey) (*Indexer[K], error) {
+func IndexerForKey[K runtime.Object](r InformerRegistry, key RegistryKey) (*Indexer[K], error) {
 	indexer, err := r.IndexerForKey(key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Introduces `dsk`: an in-process simulation layer for testing Kubernetes controllers. 

Check out the [README](https://github.com/ecordell/controller-idioms/blob/evan/dsk/dsk/README.md) for an in depth overview.

The core abstraction is the **tick**: a deterministic delta cycle that buffers watch events and delivers them only when the test calls `Flush()` or `Tick()`, then waits for all resulting reconciles to complete before returning. This is borrowed from VHDL delta-cycle simulation (which I have read about but never used, I could be stretching the analogy without realizing).

This makes some difficult to test controller bug classes testable:
- **Convergence**: tick until `IsSteady()` or fail at a max-tick limit, catching both slow convergence (assert on tick count) and infinite requeue loops (never reaches steady state)
- **Ordering races between controllers**: `Buffer()` returns pending events as a slice; tests can explicitly deliver them in any order or use a property-testing library to enumerate all permutations

`dsk` works with both fake clients (reactor path) and real clients via envtest/kind (HTTP transport path). 

It also includes:
- fault injection via a chainable `FaultBuilder` DSL
- an `asynchandler` static analyzer that catches `AddRateLimited` calls inside reconcile handlers before `Done()` is called (this is almost always a bug, but it's important for the correctness of dsk that queue add calls be syncronous)