### PR TITLE
fix: bail from EnsureComponentByHash.Handle when newObj signals requeue

### DIFF
--- a/component/ensure_component.go
+++ b/component/ensure_component.go
@@ -55,6 +55,11 @@ func (e *EnsureComponentByHash[K, A]) Handle(ctx context.Context) {
 	ownedObjs := e.List(ctx, e.nn.MustValue(ctx))
 
 	newObj := e.newObj(ctx)
+	// newObj may have signaled a requeue (e.g. RequeueAPIErr) which cancels
+	// the handler context; bail out before dereferencing the result.
+	if ctx.Err() != nil {
+		return
+	}
 	hash := e.Hash(newObj)
 	newObj = newObj.WithAnnotations(map[string]string{e.HashAnnotationKey: hash})
 

--- a/component/ensure_component_test.go
+++ b/component/ensure_component_test.go
@@ -2,8 +2,10 @@ package component
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -173,4 +175,84 @@ func TestEnsureServiceHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEnsureComponentByHashStopsWhenNewObjSignalsRequeue guards against a panic
+// where a newObj factory both calls a queue operation (e.g. RequeueAPIErr) and
+// returns nil. RequeueAPIErr cancels the handler context but does not unwind
+// the goroutine, so without a ctx.Err() check the framework would dereference
+// the nil to attach a hash annotation and segfault. Reproduces the panic
+// observed at authzed/internal#10787.
+func TestEnsureComponentByHashStopsWhenNewObjSignalsRequeue(t *testing.T) {
+	const (
+		hashKey    = "example.com/component-hash"
+		ownerIndex = "owner"
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	serviceGVR := corev1.SchemeGroupVersion.WithResource("services")
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	client := clientfake.NewSimpleDynamicClient(scheme)
+	informerFactory := dynamicinformer.NewDynamicSharedInformerFactory(client, 0)
+	require.NoError(t, informerFactory.ForResource(serviceGVR).Informer().AddIndexers(map[string]cache.IndexFunc{
+		ownerIndex: func(_ interface{}) ([]string, error) {
+			return []string{types.NamespacedName{Namespace: "test", Name: "owner"}.String()}, nil
+		},
+	}))
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+	indexer := typed.NewIndexer[*corev1.Service](informerFactory.ForResource(serviceGVR).Informer().GetIndexer())
+	ctxOwner := typedctx.WithDefault[types.NamespacedName](types.NamespacedName{Namespace: "test", Name: "owner"})
+
+	queueOps := queue.NewQueueOperationsCtx()
+
+	// Simulate the manager plumbing: a real Operations whose cancel func
+	// cancels the handler-scoped context, so RequeueAPIErr propagates via
+	// ctx.Err() the same way it does in production.
+	handlerCtx, cancelHandler := context.WithCancel(ctx)
+	defer cancelHandler()
+	ops := queue.NewOperations(func() {}, func(time.Duration) {}, cancelHandler)
+	handlerCtx = queueOps.WithValue(handlerCtx, ops)
+
+	simulatedErr := errors.New("simulated upstream failure")
+	applyCalled := false
+	deleteCalled := false
+
+	h := handler.NewHandler(NewEnsureComponentByHash(
+		NewHashableComponent[*corev1.Service](
+			NewIndexedComponent(
+				indexer,
+				ownerIndex,
+				func(_ context.Context) labels.Selector {
+					return labels.SelectorFromSet(map[string]string{
+						"example.com/component": "the-main-service-component",
+					})
+				}),
+			hash.NewObjectHash(), hashKey),
+		ctxOwner,
+		queueOps,
+		func(_ context.Context, _ *applycorev1.ServiceApplyConfiguration) (*corev1.Service, error) {
+			applyCalled = true
+			return nil, nil
+		},
+		func(_ context.Context, _ types.NamespacedName) error {
+			deleteCalled = true
+			return nil
+		},
+		func(ctx context.Context) *applycorev1.ServiceApplyConfiguration {
+			queueOps.RequeueAPIErr(ctx, simulatedErr)
+			return nil
+		}), "ensureService")
+
+	require.NotPanics(t, func() {
+		h.Handle(handlerCtx)
+	})
+
+	require.False(t, applyCalled, "must not apply when newObj signaled requeue")
+	require.False(t, deleteCalled, "must not delete when newObj signaled requeue")
+	require.Equal(t, simulatedErr, ops.Error(), "Operations must record the requeue error")
+	require.Error(t, handlerCtx.Err(), "handler context must be cancelled by RequeueAPIErr")
 }


### PR DESCRIPTION
## What

`EnsureComponentByHash.Handle` calls the user-supplied `newObj(ctx)` factory and then immediately dereferences the result via `e.Hash(newObj)` and `newObj.WithAnnotations(...)`. If the factory both signals a requeue (e.g. `RequeueAPIErr`) and returns a zero-value apply configuration, the framework segfaults on the deref.

This change adds a `ctx.Err() != nil` short-circuit immediately after `newObj(ctx)` and returns early. The check uses the canonical context-cancellation pattern already documented in `queue/handlers.go` and used by `state.Continue`, `queue.OnError`, and parallel execution.

```go
newObj := e.newObj(ctx)
// newObj may have signaled a requeue (e.g. RequeueAPIErr) which cancels
// the handler context; bail out before dereferencing the result.
if ctx.Err() != nil {
    return
}
hash := e.Hash(newObj)
newObj = newObj.WithAnnotations(map[string]string{e.HashAnnotationKey: hash})
```

A regression test (`TestEnsureComponentByHashStopsWhenNewObjSignalsRequeue`) plumbs a real `queue.Operations` whose cancel func cancels the handler context — mirroring the manager's plumbing — and asserts the handler does not panic, does not call `applyObject`/`deleteObject`, records the requeue error, and exits cleanly.

## Why

We hit this in production downstream. Stack trace from the operator:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1612a4b]

k8s.io/client-go/applyconfigurations/core/v1.(*SecretApplyConfiguration).WithAnnotations(0x0, ...)
    .../client-go/applyconfigurations/core/v1/secret.go:225 +0x2b
github.com/authzed/controller-idioms/component.(*EnsureComponentByHash[...]).Handle(...)
    .../controller-idioms/component/ensure_component.go:59 +0x1b9
```

The receiver in `WithAnnotations(0x0, ...)` confirmed the apply config was nil. The downstream factory had a path that called `RequeueAPIErr` (when a status patch failed) and returned `nil`. `RequeueAPIErr` cancels the handler context via the `Operations.cancel` func but does not unwind the goroutine, so the nil reached `Handle` and crashed the controller.

Fixing the contract violation in the caller is necessary regardless, but the framework should also not segfault on a misbehaving factory. The `ctx.Err()` check makes the framework honor the same "stop when the queue says stop" contract that `state.Continue` and `OnError` already use.

## Test plan

- [x] Regression test fails before the fix with the exact production stack (`(*ServiceApplyConfiguration).WithAnnotations(0x0, ...)` at `ensure_component.go:59`) and passes after
- [x] `go test -race ./...` passes across all packages
- [x] `golangci-lint run ./component/...` reports 0 issues